### PR TITLE
supports lookbehinds

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ exports.removeBackslashes = str => {
 
 exports.supportsLookbehinds = () => {
   let segs = process.version.slice(1).split('.');
-  if (segs.length === 3 && +segs[0] >= 8 && +segs[1] >= 10) {
+  if (segs.length === 3 && +segs[0] >= 9 || (+segs[0] === 8 && +segs[1] >= 10)) {
     return true;
   }
   return false;


### PR DESCRIPTION
I noticed in another PR to micromatch that some tests were failing because node `12.2.0` would cause the `utils.supportsLookbehinds` method to return `false`.

- only check minor when major is version 8
- all majors greater than or equal to 9 support lookbehinds