### PR TITLE
Fix "Extglobs" table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Picomatch's matching features and expected results in unit tests are based on Ba
 ### Extglobs
 
 | **Pattern** | **Description** |
-| --- | --- | --- |
+| --- | --- |
 | `@(pattern)` | Match _only one_ consecutive occurrence of `pattern` |
 | `*(pattern)` | Match _zero or more_ consecutive occurrences of `pattern` |
 | `+(pattern)` | Match _one or more_ consecutive occurrences of `pattern` |


### PR DESCRIPTION
It wasn't properly displayed as a table