### PR TITLE
Enable linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -112,6 +112,7 @@
     "one-var": [0, { "initialized": "never" }],
     "operator-linebreak": [0, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": [0, "never"],
+    "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,
     "semi": [2, "always"],

--- a/bench/glob-parent.js
+++ b/bench/glob-parent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Suite } = require('benchmark');
-const { cyan, red, green } = require('ansi-colors');
+const { red } = require('ansi-colors');
 const argv = require('minimist')(process.argv.slice(2));
 const parent = require('glob-parent');
 const scan = require('../lib/scan');
@@ -11,7 +11,7 @@ const scan = require('../lib/scan');
  */
 
 const cycle = (e, newline) => {
-  process.stdout.write(`\u001b[G  ${e.target}${newline ? `\n` : ''}`);
+  process.stdout.write(`\u001b[G  ${e.target}${newline ? '\n' : ''}`);
 };
 
 function bench(name, options) {

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Suite } = require('benchmark');
-const { cyan, red, green } = require('ansi-colors');
+const { red } = require('ansi-colors');
 const argv = require('minimist')(process.argv.slice(2));
 const mm = require('../node_modules/minimatch');
 const pm = require('..');
@@ -11,7 +11,7 @@ const pm = require('..');
  */
 
 const cycle = (e, newline) => {
-  process.stdout.write(`\u001b[G  ${e.target}${newline ? `\n` : ''}`);
+  process.stdout.write(`\u001b[G  ${e.target}${newline ? '\n' : ''}`);
 };
 
 const bench = (name, options) => {

--- a/examples/extglob.js
+++ b/examples/extglob.js
@@ -1,6 +1,5 @@
 const pm = require('..');
 
-
 console.log(pm.makeRe('(a|b|c)'));
 console.log(pm.makeRe('!(a|b|c)'));
 console.log(pm.makeRe('*(a|b|c)'));

--- a/examples/match.js
+++ b/examples/match.js
@@ -15,8 +15,8 @@ const match = (list, pattern, options = {}) => {
     normalize = true;
   }
 
-  let isMatch = pm(pattern, options);
-  let matches = new Set();
+  const isMatch = pm(pattern, options);
+  const matches = new Set();
   for (let ele of list) {
     if (normalize === true || options.normalize === true) {
       ele = path.posix.normalize(ele);
@@ -28,7 +28,7 @@ const match = (list, pattern, options = {}) => {
   return [...matches];
 };
 
-let fixtures = ['a.md', 'a/b.md', './a.md', './a/b.md', 'a/b/c.md', './a/b/c.md', '.\\a\\b\\c.md', 'a\\b\\c.md'];
+const fixtures = ['a.md', 'a/b.md', './a.md', './a/b.md', 'a/b/c.md', './a/b/c.md', '.\\a\\b\\c.md', 'a\\b\\c.md'];
 
 console.log(path.posix.normalize('./{a,b,c}/*.md'));
 console.log(match(fixtures, './**/*.md'));

--- a/examples/match.js
+++ b/examples/match.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const assert = require('assert');
+// const assert = require('assert');
 const pm = require('..');
 
 /**

--- a/examples/option-expandRange.js
+++ b/examples/option-expandRange.js
@@ -11,9 +11,9 @@ const regex = pm.makeRe('foo/{01..25}/bar', {
 console.log(regex);
 //=> /^(?:foo\/((?:0[1-9]|1[0-9]|2[0-5]))\/bar)$/
 
-console.log(regex.test('foo/00/bar')) // false
-console.log(regex.test('foo/01/bar')) // true
-console.log(regex.test('foo/10/bar')) // true
-console.log(regex.test('foo/22/bar')) // true
-console.log(regex.test('foo/25/bar')) // true
-console.log(regex.test('foo/26/bar')) // false
+console.log(regex.test('foo/00/bar')); // false
+console.log(regex.test('foo/01/bar')); // true
+console.log(regex.test('foo/10/bar')); // true
+console.log(regex.test('foo/22/bar')); // true
+console.log(regex.test('foo/25/bar')); // true
+console.log(regex.test('foo/26/bar')); // false

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,7 +28,7 @@ const expandRange = (args, options) => {
   const value = `[${args.join('-')}]`;
 
   try {
-    /* eslint-disable no-new */
+    /* eslint-disable-next-line no-new */
     new RegExp(value);
   } catch (ex) {
     return args.map(v => utils.escapeRegex(v)).join('..');

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -25,7 +25,7 @@ const expandRange = (args, options) => {
   }
 
   args.sort();
-  let value = `[${args.join('-')}]`;
+  const value = `[${args.join('-')}]`;
 
   try {
     /* eslint-disable no-new */
@@ -77,18 +77,18 @@ const parse = (input, options) => {
 
   input = REPLACEMENTS[input] || input;
 
-  let opts = { ...options };
-  let max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
-  let len = input.length;
+  const opts = { ...options };
+  const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+  const len = input.length;
   if (len > max) {
     throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
   }
 
-  let bos = { type: 'bos', value: '', output: opts.prepend || '' };
-  let tokens = [bos];
+  const bos = { type: 'bos', value: '', output: opts.prepend || '' };
+  const tokens = [bos];
 
-  let capture = opts.capture ? '' : '?:';
-  let win32 = utils.isWindows(options);
+  const capture = opts.capture ? '' : '?:';
+  const win32 = utils.isWindows(options);
 
   // create constants based on platform, for windows or posix
   const PLATFORM_CHARS = constants.globChars(win32);
@@ -113,9 +113,9 @@ const parse = (input, options) => {
     return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
   };
 
-  let nodot = opts.dot ? '' : NO_DOT;
+  const nodot = opts.dot ? '' : NO_DOT;
   let star = opts.bash === true ? globstar(opts) : STAR;
-  let qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+  const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
 
   if (opts.capture) {
     star = `(${star})`;
@@ -126,7 +126,7 @@ const parse = (input, options) => {
     opts.noextglob = opts.noext;
   }
 
-  let state = {
+  const state = {
     index: -1,
     start: 0,
     consumed: '',
@@ -139,8 +139,8 @@ const parse = (input, options) => {
     tokens
   };
 
-  let extglobs = [];
-  let stack = [];
+  const extglobs = [];
+  const stack = [];
   let prev = bos;
   let value;
 
@@ -176,8 +176,8 @@ const parse = (input, options) => {
 
   const push = tok => {
     if (prev.type === 'globstar') {
-      let isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
-      let isExtglob = extglobs.length && (tok.type === 'pipe' || tok.type === 'paren');
+      const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
+      const isExtglob = extglobs.length && (tok.type === 'pipe' || tok.type === 'paren');
       if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
         state.output = state.output.slice(0, -prev.output.length);
         prev.type = 'star';
@@ -203,12 +203,12 @@ const parse = (input, options) => {
   };
 
   const extglobOpen = (type, value) => {
-    let token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
+    const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
 
     token.prev = prev;
     token.parens = state.parens;
     token.output = state.output;
-    let output = (opts.capture ? '(' : '') + token.open;
+    const output = (opts.capture ? '(' : '') + token.open;
 
     push({ type, value, output: state.output ? '' : ONE_CHAR });
     push({ type: 'paren', extglob: true, value: advance(), output });
@@ -301,7 +301,7 @@ const parse = (input, options) => {
      */
 
     if (value === '\\') {
-      let next = peek();
+      const next = peek();
 
       if (next === '/' && opts.bash !== true) {
         continue;
@@ -841,7 +841,7 @@ const parse = (input, options) => {
       continue;
     }
 
-    let token = { type: 'star', value, output: star };
+    const token = { type: 'star', value, output: star };
 
     if (opts.bash === true) {
       token.output = '.*?';
@@ -907,7 +907,7 @@ const parse = (input, options) => {
   if (state.backtrack === true) {
     state.output = '';
 
-    for (let token of state.tokens) {
+    for (const token of state.tokens) {
       state.output += token.output != null ? token.output : token.value;
 
       if (token.suffix) {
@@ -989,10 +989,10 @@ parse.fastpaths = (input, options) => {
         return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
 
       default: {
-        let match = /^(.*?)\.(\w+)$/.exec(str);
+        const match = /^(.*?)\.(\w+)$/.exec(str);
         if (!match) return;
 
-        let source = create(match[1], options);
+        const source = create(match[1], options);
         if (!source) return;
 
         return source + DOT_LITERAL + match[2];

--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -32,7 +32,7 @@ const picomatch = (glob, options, returnState = false) => {
   if (Array.isArray(glob)) {
     const fns = glob.map(input => picomatch(input, options, returnState));
     return str => {
-      for (let isMatch of fns) {
+      for (const isMatch of fns) {
         const state = isMatch(str);
         if (state) return state;
       }
@@ -52,13 +52,13 @@ const picomatch = (glob, options, returnState = false) => {
 
   let isIgnored = () => false;
   if (opts.ignore) {
-    let ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+    const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
     isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
   }
 
   const matcher = (input, returnObject = false) => {
-    let { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
-    let result = { glob, state, regex, posix, input, output, match, isMatch };
+    const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+    const result = { glob, state, regex, posix, input, output, match, isMatch };
 
     if (typeof opts.onResult === 'function') {
       opts.onResult(result);

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -145,7 +145,7 @@ module.exports = (input, options) => {
       }
     }
 
-    let isExtglobChar = code === CHAR_PLUS
+    const isExtglobChar = code === CHAR_PLUS
       || code === CHAR_AT
       || code === CHAR_EXCLAMATION_MARK;
 
@@ -181,7 +181,7 @@ module.exports = (input, options) => {
   }
 
   let prefix = '';
-  let orig = input;
+  const orig = input;
   let base = input;
   let glob = '';
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@ exports.removeBackslashes = str => {
   return str.replace(REGEX_REMOVE_BACKSLASH, match => {
     return match === '\\' ? '' : match;
   });
-}
+};
 
 exports.supportsLookbehinds = () => {
   const segs = process.version.slice(1).split('.');

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "node": ">=8"
   },
   "scripts": {
+    "pretest": "eslint .",
     "test": "mocha",
     "cover": "nyc --reporter=text --reporter=html mocha"
   },
   "devDependencies": {
+    "eslint": "^6.4.0",
     "fill-range": "^7.0.1",
     "gulp-format-md": "^2.0.0",
     "mocha": "^6.0.2",

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -5,7 +5,7 @@ const assert = require('assert').strict;
 const scan = require('../lib/scan');
 const base = (...args) => scan(...args).base;
 const both = (...args) => {
-  let { base, glob } = scan(...args);
+  const { base, glob } = scan(...args);
   return [base, glob];
 };
 
@@ -273,7 +273,7 @@ describe('picomatch', () => {
     });
 
     it('should support regex character classes', () => {
-      let opts = { unescape: true };
+      const opts = { unescape: true };
       assert.deepEqual(both('[a-c]b*'), ['', '[a-c]b*']);
       assert.deepEqual(both('[a-j]*[^c]'), ['', '[a-j]*[^c]']);
       assert.deepEqual(both('[a-j]*[^c]b/c'), ['', '[a-j]*[^c]b/c']);
@@ -355,7 +355,7 @@ describe('picomatch', () => {
     });
 
     it('should respect brace enclosures with embedded separators', () => {
-      let opts = { unescape: true };
+      const opts = { unescape: true };
       assert.equal(base('path/{,/,bar/baz,qux}/', opts), 'path');
       assert.equal(base('path/\\{,/,bar/baz,qux}/', opts), 'path/{,/,bar/baz,qux}/');
       assert.equal(base('path/\\{,/,bar/baz,qux\\}/', opts), 'path/{,/,bar/baz,qux}/');
@@ -367,7 +367,7 @@ describe('picomatch', () => {
     });
 
     it('should handle escaped nested braces', () => {
-      let opts = { unescape: true };
+      const opts = { unescape: true };
       assert.equal(base('\\{../,./,\\{bar,/baz},qux}', opts), '{../,./,{bar,/baz},qux}');
       assert.equal(base('\\{../,./,\\{bar,/baz},qux}/', opts), '{../,./,{bar,/baz},qux}/');
       assert.equal(base('path/\\{,/,bar/{baz,qux}}/', opts), 'path/{,/,bar/{baz,qux}}/');
@@ -378,7 +378,7 @@ describe('picomatch', () => {
     });
 
     it('should recognize escaped braces', () => {
-      let opts = { unescape: true };
+      const opts = { unescape: true };
       assert.equal(base('\\{foo,bar\\}', opts), '{foo,bar}');
       assert.equal(base('\\{foo,bar\\}/', opts), '{foo,bar}/');
       assert.equal(base('\\{foo,bar}/', opts), '{foo,bar}/');

--- a/test/dotfiles.js
+++ b/test/dotfiles.js
@@ -28,7 +28,7 @@ describe('dotfiles', () => {
     });
 
     it('should match dotfiles when there is a leading dot:', () => {
-      let opts = { dot: true };
+      const opts = { dot: true };
       assert.deepEqual(match(['.dotfile'], '*', opts), ['.dotfile']);
       assert.deepEqual(match(['.dotfile'], '**', opts), ['.dotfile']);
       assert.deepEqual(match(['a/b', 'a/.b', '.a/b', '.a/.b'], '**', opts), ['a/b', 'a/.b', '.a/b', '.a/.b']);
@@ -40,7 +40,7 @@ describe('dotfiles', () => {
     });
 
     it('should match dotfiles when there is not a leading dot:', () => {
-      let opts = { dot: true };
+      const opts = { dot: true };
       assert.deepEqual(match(['.dotfile'], '*.*', opts), ['.dotfile']);
       assert.deepEqual(match(['.a', '.b', 'c', 'c.md'], '*.*', opts), ['.a', '.b', 'c.md']);
       assert.deepEqual(match(['.dotfile'], '*.md', opts), []);
@@ -61,7 +61,7 @@ describe('dotfiles', () => {
 
   describe('options.dot', () => {
     it('should match dotfiles when `options.dot` is true:', () => {
-      let fixtures = ['a/./b', 'a/../b', 'a/c/b', 'a/.d/b'];
+      const fixtures = ['a/./b', 'a/../b', 'a/c/b', 'a/.d/b'];
       assert.deepEqual(match(['.dotfile'], '*.*', { dot: true }), ['.dotfile']);
       assert.deepEqual(match(['.dotfile'], '*.md', { dot: true }), []);
       assert.deepEqual(match(['.dotfile'], '.dotfile', { dot: true }), ['.dotfile']);

--- a/test/extglobs-temp.js
+++ b/test/extglobs-temp.js
@@ -1058,7 +1058,7 @@ describe('extglobs', () => {
     });
 
     it('should work with character classes', () => {
-      let opts = { posix: true };
+      const opts = { posix: true };
       assert(isMatch('a.b', 'a[^[:alnum:]]b', opts));
       assert(isMatch('a,b', 'a[^[:alnum:]]b', opts));
       assert(isMatch('a:b', 'a[^[:alnum:]]b', opts));
@@ -1133,7 +1133,7 @@ describe('extglobs', () => {
     });
 
     it('should support POSIX character classes in extglobs', () => {
-      let opts = { posix: true };
+      const opts = { posix: true };
       assert(isMatch('a.c', '+([[:alpha:].])', opts));
       assert(isMatch('a.c', '+([[:alpha:].])+([[:alpha:].])', opts));
       assert(isMatch('a.c', '*([[:alpha:].])', opts));

--- a/test/extglobs.js
+++ b/test/extglobs.js
@@ -11,7 +11,7 @@ const { isMatch, makeRe } = require('..');
 
 describe('extglobs', () => {
   it('should throw on imbalanced sets when `options.strictBrackets` is true', () => {
-    let opts = { strictBrackets: true };
+    const opts = { strictBrackets: true };
     assert.throws(() => makeRe('a(b', opts), /Missing closing: "\)"/i);
     assert.throws(() => makeRe('a)b', opts), /Missing opening: "\("/i);
   });
@@ -713,7 +713,7 @@ describe('extglobs', () => {
   // these are not extglobs, and do not need to pass, but they are included
   // to test integration with other features
   it('should support regex characters', () => {
-    let fixtures = ['a c', 'a.c', 'a.xy.zc', 'a.zc', 'a123c', 'a1c', 'abbbbc', 'abbbc', 'abbc', 'abc', 'abq', 'axy zc', 'axy', 'axy.zc', 'axyzc'];
+    const fixtures = ['a c', 'a.c', 'a.xy.zc', 'a.zc', 'a123c', 'a1c', 'abbbbc', 'abbbc', 'abbc', 'abc', 'abq', 'axy zc', 'axy', 'axy.zc', 'axyzc'];
 
     if (process.platform !== 'win32') {
       assert.deepEqual(match(['a\\b', 'a/b', 'ab'], 'a/b'), ['a/b']);

--- a/test/globstars.js
+++ b/test/globstars.js
@@ -35,7 +35,7 @@ describe('stars', () => {
     });
 
     it('should respect trailing slashes on paterns', () => {
-      let fixtures = ['a', 'a/', 'a/a', 'a/a/', 'a/a/a', 'a/a/a/', 'a/a/a/a', 'a/a/a/a/', 'a/a/a/a/a', 'a/a/a/a/a/', 'a/a/b', 'a/a/b/', 'a/b', 'a/b/', 'a/b/c/.d/e/', 'a/c', 'a/c/', 'a/b', 'a/x/', 'b', 'b/', 'x/y', 'x/y/', 'z/z', 'z/z/'];
+      const fixtures = ['a', 'a/', 'a/a', 'a/a/', 'a/a/a', 'a/a/a/', 'a/a/a/a', 'a/a/a/a/', 'a/a/a/a/a', 'a/a/a/a/a/', 'a/a/b', 'a/a/b/', 'a/b', 'a/b/', 'a/b/c/.d/e/', 'a/c', 'a/c/', 'a/b', 'a/x/', 'b', 'b/', 'x/y', 'x/y/', 'z/z', 'z/z/'];
 
       assert.deepEqual(match(fixtures, '**/*/a/'), ['a/a/', 'a/a/a/', 'a/a/a/a/', 'a/a/a/a/a/']);
       assert.deepEqual(match(fixtures, '**/*/a/*/'), ['a/a/a/', 'a/a/a/a/', 'a/a/a/a/a/', 'a/a/b/']);
@@ -52,7 +52,7 @@ describe('stars', () => {
     });
 
     it('should match literal globstars when stars are escaped', () => {
-      let fixtures = ['.md', '**a.md', '**.md', '.md', '**'];
+      const fixtures = ['.md', '**a.md', '**.md', '.md', '**'];
       assert.deepEqual(match(fixtures, '\\*\\**.md'), ['**a.md', '**.md']);
       assert.deepEqual(match(fixtures, '\\*\\*.md'), ['**.md']);
     });
@@ -286,7 +286,7 @@ describe('stars', () => {
     });
 
     it('should match leading dots when defined in pattern', () => {
-      let fixtures = ['.gitignore', 'a/b/z/.dotfile', 'a/b/z/.dotfile.md', 'a/b/z/.dotfile.md', 'a/b/z/.dotfile.md'];
+      const fixtures = ['.gitignore', 'a/b/z/.dotfile', 'a/b/z/.dotfile.md', 'a/b/z/.dotfile.md', 'a/b/z/.dotfile.md'];
       assert(!isMatch('.gitignore', 'a/**/z/*.md'));
       assert(!isMatch('a/b/z/.dotfile', 'a/**/z/*.md'));
       assert(!isMatch('a/b/z/.dotfile.md', '**/c/.*.md'));

--- a/test/globstars.js
+++ b/test/globstars.js
@@ -3,7 +3,7 @@
 require('mocha');
 const assert = require('assert').strict;
 const match = require('./support/match');
-const { isMatch, makeRe } = require('..');
+const { isMatch } = require('..');
 
 describe('stars', () => {
   describe('issue related', () => {

--- a/test/minimatch.js
+++ b/test/minimatch.js
@@ -30,7 +30,7 @@ describe('minimatch parity:', () => {
     });
 
     it('https://github.com/isaacs/minimatch/issues/67 (should work consistently with `makeRe` and matcher functions)', () => {
-      let re = makeRe('node_modules/foobar/**/*.bar');
+      const re = makeRe('node_modules/foobar/**/*.bar');
       assert(re.test('node_modules/foobar/foo.bar'));
       assert(isMatch('node_modules/foobar/foo.bar', 'node_modules/foobar/**/*.bar'));
     });

--- a/test/options.format.js
+++ b/test/options.format.js
@@ -13,8 +13,8 @@ describe('options.format', () => {
 
   // see https://github.com/isaacs/minimatch/issues/30
   it('should match the string returned by options.format', () => {
-    let opts = { format: str => str.replace(/\\/g, '/').replace(/^\.\//, ''), strictSlashes: true };
-    let fixtures = ['a', './a', 'b', 'a/a', './a/b', 'a/c', './a/x', './a/a/a', 'a/a/b', './a/a/a/a', './a/a/a/a/a', 'x/y', './z/z'];
+    const opts = { format: str => str.replace(/\\/g, '/').replace(/^\.\//, ''), strictSlashes: true };
+    const fixtures = ['a', './a', 'b', 'a/a', './a/b', 'a/c', './a/x', './a/a/a', 'a/a/b', './a/a/a/a', './a/a/a/a/a', 'x/y', './z/z'];
 
     assert(!isMatch('./.a', '*.a', opts));
     assert(!isMatch('./.a', './*.a', opts));

--- a/test/options.ignore.js
+++ b/test/options.ignore.js
@@ -13,12 +13,12 @@ describe('options.ignore', () => {
     assert(!isMatch('+b/src/glimini.js', '+b/src/*', { ignore: ['**/*.js'] }));
   });
 
-  let negations = ['a/a', 'a/b', 'a/c', 'a/d', 'a/e', 'b/a', 'b/b', 'b/c'];
-  let globs = ['.a', '.a/a', '.a/a/a', '.a/a/a/a', 'a', 'a/.a', 'a/a', 'a/a/.a', 'a/a/a', 'a/a/a/a', 'a/a/a/a/a', 'a/a/b', 'a/b', 'a/b/c', 'a/c', 'a/x', 'b', 'b/b/b', 'b/b/c', 'c/c/c', 'e/f/g', 'h/i/a', 'x/x/x', 'x/y', 'z/z', 'z/z/z'].sort();
+  const negations = ['a/a', 'a/b', 'a/c', 'a/d', 'a/e', 'b/a', 'b/b', 'b/c'];
+  const globs = ['.a', '.a/a', '.a/a/a', '.a/a/a/a', 'a', 'a/.a', 'a/a', 'a/a/.a', 'a/a/a', 'a/a/a/a', 'a/a/a/a/a', 'a/a/b', 'a/b', 'a/b/c', 'a/c', 'a/x', 'b', 'b/b/b', 'b/b/c', 'c/c/c', 'e/f/g', 'h/i/a', 'x/x/x', 'x/y', 'z/z', 'z/z/z'].sort();
 
   it('should filter out ignored patterns', () => {
-    let opts = { ignore: ['a/**'], strictSlashes: true };
-    let dotOpts = { ...opts, dot: true };
+    const opts = { ignore: ['a/**'], strictSlashes: true };
+    const dotOpts = { ...opts, dot: true };
 
     assert.deepEqual(match(globs, '*', opts), ['b']);
     assert.deepEqual(match(globs, '*', { ignore: '**/a' }), ['b']);

--- a/test/options.js
+++ b/test/options.js
@@ -50,7 +50,7 @@ describe('options', () => {
     });
 
     it('should not double-set `i` when both `nocase` and the `i` flag are set', () => {
-      let opts = { nocase: true, flags: 'i' };
+      const opts = { nocase: true, flags: 'i' };
       assert.deepEqual(match(['a/b/d/e.md'], 'a/b/D/*.md', opts), ['a/b/d/e.md']);
       assert.deepEqual(match(['a/b/c/e.md'], 'A/b/*/E.md', opts), ['a/b/c/e.md']);
       assert.deepEqual(match(['a/b/c/e.md'], 'A/b/C/*.MD', opts), ['a/b/c/e.md']);
@@ -88,7 +88,7 @@ describe('options', () => {
 
   describe('options.unescape', () => {
     it('should remove backslashes in glob patterns:', () => {
-      let fixtures = ['abc', '/a/b/c', '\\a\\b\\c'];
+      const fixtures = ['abc', '/a/b/c', '\\a\\b\\c'];
       assert.deepEqual(match(fixtures, '\\a\\b\\c'), ['/a/b/c']);
       assert.deepEqual(match(fixtures, '\\a\\b\\c', { unescape: true }), ['abc', '/a/b/c']);
       assert.deepEqual(match(fixtures, '\\a\\b\\c', { unescape: false }), ['/a/b/c']);
@@ -116,9 +116,9 @@ describe('options', () => {
     });
 
     it('should strip leading `./`', () => {
-      let fixtures = ['./a', './a/a/a', './a/a/a/a', './a/a/a/a/a', './a/b', './a/x', './z/z', 'a', 'a/a', 'a/a/b', 'a/c', 'b', 'x/y'].sort();
-      let format = str => str.replace(/^\.\//, '');
-      let opts = { format };
+      const fixtures = ['./a', './a/a/a', './a/a/a/a', './a/a/a/a/a', './a/b', './a/x', './z/z', 'a', 'a/a', 'a/a/b', 'a/c', 'b', 'x/y'].sort();
+      const format = str => str.replace(/^\.\//, '');
+      const opts = { format };
       assert.deepEqual(match(fixtures, '*', opts), ['a', 'b']);
       assert.deepEqual(match(fixtures, '**/a/**', opts), ['a', 'a/a/a', 'a/a/a/a', 'a/a/a/a/a', 'a/b', 'a/x', 'a/a', 'a/a/b', 'a/c']);
       assert.deepEqual(match(fixtures, '*/*', opts), ['a/b', 'a/x', 'z/z', 'a/a', 'a/c', 'x/y']);

--- a/test/options.onMatch.js
+++ b/test/options.onMatch.js
@@ -27,7 +27,7 @@ const options = () => {
 
 describe('options.onMatch', () => {
   it('should call options.onMatch on each matching string', () => {
-    let fixtures = ['a', './a', 'b', 'a/a', './a/b', 'a/c', './a/x', './a/a/a', 'a/a/b', './a/a/a/a', './a/a/a/a/a', 'x/y', './z/z'];
+    const fixtures = ['a', './a', 'b', 'a/a', './a/b', 'a/c', './a/x', './a/a/a', 'a/a/b', './a/a/a/a', './a/a/a/a/a', 'x/y', './z/z'];
 
     assert(!isMatch('./.a', '*.a', { format }));
     assert(!isMatch('./.a', './*.a', { format }));

--- a/test/posix-classes.js
+++ b/test/posix-classes.js
@@ -8,7 +8,7 @@ const { makeRe, parse } = pm;
 const opts = { strictSlashes: true, posix: true, regex: true };
 const isMatch = (...args) => pm.isMatch(...args, opts);
 const convert = (...args) => {
-  let state = parse(...args, opts);
+  const state = parse(...args, opts);
   return state.output;
 };
 

--- a/test/qmarks.js
+++ b/test/qmarks.js
@@ -50,7 +50,7 @@ describe('qmarks and stars', () => {
   });
 
   it('should match one character per question mark', () => {
-    let fixtures = ['a', 'aa', 'ab', 'aaa', 'abcdefg'];
+    const fixtures = ['a', 'aa', 'ab', 'aaa', 'abcdefg'];
     assert.deepEqual(match(fixtures, '?'), ['a']);
     assert.deepEqual(match(fixtures, '??'), ['aa', 'ab']);
     assert.deepEqual(match(fixtures, '???'), ['aaa']);
@@ -64,7 +64,7 @@ describe('qmarks and stars', () => {
   });
 
   it('should not match slashes question marks', () => {
-    let fixtures = ['//', 'a/', '/a', '/a/', 'aa', '/aa', 'a/a', 'aaa', '/aaa'];
+    const fixtures = ['//', 'a/', '/a', '/a/', 'aa', '/aa', 'a/a', 'aaa', '/aaa'];
     assert.deepEqual(match(fixtures, '/?'), ['/a']);
     assert.deepEqual(match(fixtures, '/??'), ['/aa']);
     assert.deepEqual(match(fixtures, '/???'), ['/aaa']);
@@ -91,7 +91,7 @@ describe('qmarks and stars', () => {
   });
 
   it('should match no more than one character between slashes', () => {
-    let fixtures = ['a/a', 'a/a/a', 'a/aa/a', 'a/aaa/a', 'a/aaaa/a', 'a/aaaaa/a'];
+    const fixtures = ['a/a', 'a/a/a', 'a/aa/a', 'a/aaa/a', 'a/aaaa/a', 'a/aaaaa/a'];
     assert.deepEqual(match(fixtures, '?/?'), ['a/a']);
     assert.deepEqual(match(fixtures, '?/???/?'), ['a/aaa/a']);
     assert.deepEqual(match(fixtures, '?/????/?'), ['a/aaaa/a']);
@@ -105,7 +105,7 @@ describe('qmarks and stars', () => {
   });
 
   it('should not match non-leading dots with question marks', () => {
-    let fixtures = ['.', '.a', 'a', 'aa', 'a.a', 'aa.a', 'aaa', 'aaa.a', 'aaaa.a', 'aaaaa'];
+    const fixtures = ['.', '.a', 'a', 'aa', 'a.a', 'aa.a', 'aaa', 'aaa.a', 'aaaa.a', 'aaaaa'];
     assert.deepEqual(match(fixtures, '?'), ['a']);
     assert.deepEqual(match(fixtures, '.?'), ['.a']);
     assert.deepEqual(match(fixtures, '?a'), ['aa']);
@@ -118,8 +118,8 @@ describe('qmarks and stars', () => {
   });
 
   it('should match non-leading dots with question marks when options.dot is true', () => {
-    let fixtures = ['.', '.a', 'a', 'aa', 'a.a', 'aa.a', '.aa', 'aaa.a', 'aaaa.a', 'aaaaa'];
-    let opts = { dot: true };
+    const fixtures = ['.', '.a', 'a', 'aa', 'a.a', 'aa.a', '.aa', 'aaa.a', 'aaaa.a', 'aaaaa'];
+    const opts = { dot: true };
     assert.deepEqual(match(fixtures, '?', opts), ['.', 'a']);
     assert.deepEqual(match(fixtures, '.?', opts), ['.a']);
     assert.deepEqual(match(fixtures, '?a', opts), ['.a', 'aa']);

--- a/test/slashes-posix.js
+++ b/test/slashes-posix.js
@@ -1149,7 +1149,7 @@ describe('slash handling - posix', () => {
   });
 
   it('should match paths with leading `./` when pattern has `./`', () => {
-    let format = str => str.replace(/^\.\//, '');
+    const format = str => str.replace(/^\.\//, '');
     assert(!isMatch('./a/b/c/d/e/z/c.md', './a/**/j/**/z/*.md', { format }));
     assert(!isMatch('./a/b/c/j/e/z/c.txt', './a/**/j/**/z/*.md', { format }));
     assert(isMatch('./a/b/c/d/e/j/n/p/o/z/c.md', './a/**/j/**/z/*.md', { format }));

--- a/test/slashes-windows.js
+++ b/test/slashes-windows.js
@@ -10,7 +10,7 @@ describe('slash handling - windows', () => {
   afterEach(() => support.resetPathSep());
 
   it('should match absolute windows paths with regex from makeRe', () => {
-    let regex = makeRe('**/path/**', { windows: true });
+    const regex = makeRe('**/path/**', { windows: true });
     assert(regex.test('C:\\Users\\user\\Projects\\project\\path\\image.jpg'));
   });
 

--- a/test/special-characters.js
+++ b/test/special-characters.js
@@ -233,13 +233,13 @@ describe('special characters', () => {
     });
 
     it('should throw an error on imbalanced, unescaped parens', () => {
-      let opts = { strictBrackets: true };
+      const opts = { strictBrackets: true };
       assert.throws(() => makeRe('*)', opts), /Missing opening: "\("/);
       assert.throws(() => makeRe('*(', opts), /Missing closing: "\)"/);
     });
 
     it('should throw an error on imbalanced, unescaped brackets', () => {
-      let opts = { strictBrackets: true };
+      const opts = { strictBrackets: true };
       assert.throws(() => makeRe('*]', opts), /Missing opening: "\["/);
       assert.throws(() => makeRe('*[', opts), /Missing closing: "\]"/);
     });

--- a/test/support/match.js
+++ b/test/support/match.js
@@ -3,11 +3,11 @@
 const picomatch = require('../..');
 
 module.exports = (list, pattern, options = {}) => {
-  let isMatch = picomatch(pattern, options, true);
-  let matches = options.matches || new Set();
+  const isMatch = picomatch(pattern, options, true);
+  const matches = options.matches || new Set();
 
-  for (let item of [].concat(list)) {
-    let match = isMatch(item, true);
+  for (const item of [].concat(list)) {
+    const match = isMatch(item, true);
     if (match && match.output && match.isMatch === true) {
       matches.add(match.output);
     }


### PR DESCRIPTION
This is a bit of a follow-up to #24, adds `prefer-const` to the eslint rules and addresses all existing eslint findings.  Additionally this replaces a `eslint-disable` hint with `eslint-disable-next-line` so the rule is not disabled for the rest of the file.