### PR TITLE
Change mocha reporter to dot.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=8.6"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --reporter dot",
     "cover": "nyc --reporter=text --reporter=html mocha"
   },
   "devDependencies": {


### PR DESCRIPTION
This brings test time down ~1s from ~15s on my Windows machine.

Linux might not see such a huge improvement, but it should still be faster.