### PR TITLE
Tweak ESLint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,25 +4,12 @@
   ],
 
   "env": {
-    "browser": false,
     "es6": true,
-    "node": true,
-    "mocha": true
+    "node": true
   },
 
   "parserOptions":{
-    "ecmaVersion": 9,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "modules": true,
-      "experimentalObjectRestSpread": true
-    }
-  },
-
-  "globals": {
-    "document": false,
-    "navigator": false,
-    "window": false
+    "ecmaVersion": 9
   },
 
   "rules": {
@@ -75,11 +62,12 @@
     "no-label-var": 2,
     "no-labels": 2,
     "no-lone-blocks": 2,
+    "no-lonely-if": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-multi-spaces": 0,
     "no-multi-str": 2,
     "no-multiple-empty-lines": [2, { "max": 1 }],
-    "no-native-reassign": 0,
+    "no-native-reassign": 2,
     "no-negated-in-lhs": 2,
     "no-new": 2,
     "no-new-func": 2,
@@ -89,7 +77,7 @@
     "no-obj-calls": 2,
     "no-octal": 2,
     "no-octal-escape": 2,
-    "no-proto": 0,
+    "no-proto": 2,
     "no-redeclare": 2,
     "no-regex-spaces": 2,
     "no-return-assign": 2,
@@ -100,17 +88,18 @@
     "no-sparse-arrays": 2,
     "no-this-before-super": 2,
     "no-throw-literal": 2,
-    "no-trailing-spaces": 0,
+    "no-trailing-spaces": 2,
     "no-undef": 2,
     "no-undef-init": 2,
     "no-unexpected-multiline": 2,
     "no-unneeded-ternary": [2, { "defaultAssignment": false }],
     "no-unreachable": 2,
+    "no-unused-expressions": 2,
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
-    "no-useless-call": 0,
+    "no-useless-call": 2,
     "no-with": 2,
     "object-curly-spacing": ["error", "always", { "objectsInObjects": true }],
-    "one-var": [0, { "initialized": "never" }],
+    "one-var": [2, { "initialized": "never" }],
     "operator-linebreak": [0, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": [0, "never"],
     "prefer-const": 2,
@@ -124,6 +113,7 @@
     "space-infix-ops": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "spaced-comment": [0, "always", { "markers": ["global", "globals", "eslint", "eslint-disable", "*package", "!", ","] }],
+    "strict": 2,
     "use-isnan": 2,
     "valid-typeof": 2,
     "wrap-iife": [2, "any"],

--- a/bench/first-match-minimatch.js
+++ b/bench/first-match-minimatch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 console.time('minimatch');
 console.log(require('minimatch').makeRe('**/*').test('foo/bar/baz/qux.js'));
 console.timeEnd('minimatch');

--- a/bench/first-match-picomatch.js
+++ b/bench/first-match-picomatch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 console.time('picomatch');
 console.log(require('..').makeRe('**/*').test('foo/bar/baz/qux.js'));
 console.timeEnd('picomatch');

--- a/bench/load-time.js
+++ b/bench/load-time.js
@@ -1,3 +1,5 @@
+'use strict';
+
 console.log('# Load time');
 console.time('picomatch');
 exports.pm = require('..');

--- a/examples/extglob.js
+++ b/examples/extglob.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const pm = require('..');
 
 console.log(pm.makeRe('(a|b|c)'));

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "../.eslintrc.json"
+  ],
+  "env": {
+    "mocha": true
+  }
+}


### PR DESCRIPTION
* add .eslintignore so that nested folders node_modules are ignored too
* remove unneeded parser options
* remove unneeded globals
* add strict
* move `mocha: true` to tests since that's where it's needed only
* enable a few other rules that the codebase already complies with

The strict addition in examples is also in #42, so one will need to be reabsed. Let me know if you want me to make any changes.

PS. IMO ESLint should be added to the devDependencies and add a script too, otherwise there's no consistency.