### PR TITLE
Add ESLint as a devDependency.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-**/node_modules/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
     "no-caller": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
+    "no-console": 0,
     "no-const-assign": 2,
     "no-control-regex": 2,
     "no-debugger": 2,

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "node": ">=8.6"
   },
   "scripts": {
+    "lint": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives --ignore-path .gitignore .",
     "mocha": "mocha --reporter dot",
-    "test": "npm run mocha",
+    "test": "npm run lint && npm run mocha",
     "cover": "nyc npm run mocha"
   },
   "devDependencies": {
+    "eslint": "^5.16.0",
     "fill-range": "^7.0.1",
     "gulp-format-md": "^2.0.0",
     "mocha": "^6.2.2",


### PR DESCRIPTION
Unfortunately, due to ESLint 6.x requiring Node.js >= 8.10, we need to stick with ESLint 5.x.