### PR TITLE
Use template literals.

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -41,32 +41,32 @@ const bench = (name, options) => {
   return suite;
 };
 
-bench(red('.makeRe') + ' star')
+bench(`${red('.makeRe')} star`)
   .add('picomatch', () => pm.makeRe('*'))
   .add('minimatch', () => mm.makeRe('*'))
   .run();
 
-bench(red('.makeRe') + ' star; dot=true')
+bench(`${red('.makeRe')} star; dot=true`)
   .add('picomatch', () => pm.makeRe('*', { dot: true }))
   .add('minimatch', () => mm.makeRe('*', { dot: true }))
   .run();
 
-bench(red('.makeRe') + ' globstar')
+bench(`${red('.makeRe')} globstar`)
   .add('picomatch', () => pm.makeRe('**'))
   .add('minimatch', () => mm.makeRe('**'))
   .run();
 
-bench(red('.makeRe') + ' globstars')
+bench(`${red('.makeRe')} globstars`)
   .add('picomatch', () => pm.makeRe('**/**/**'))
   .add('minimatch', () => mm.makeRe('**/**/**'))
   .run();
 
-bench(red('.makeRe') + ' with leading star')
+bench(`${red('.makeRe')} with leading star`)
   .add('picomatch', () => pm.makeRe('*.txt'))
   .add('minimatch', () => mm.makeRe('*.txt'))
   .run();
 
-bench(red('.makeRe') + ' - basic braces')
+bench(`${red('.makeRe')} - basic braces`)
   .add('picomatch', () => pm.makeRe('{a,b,c}*.txt'))
   .add('minimatch', () => mm.makeRe('{a,b,c}*.txt'))
   .run();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -241,7 +241,7 @@ const parse = (input, options) => {
       }
 
       if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
-        output = token.close = ')$))' + extglobStar;
+        output = token.close = `)$))${extglobStar}`;
       }
 
       if (token.prev.type === 'bos' && eos()) {
@@ -286,7 +286,7 @@ const parse = (input, options) => {
         }
         return star;
       }
-      return esc ? m : '\\' + m;
+      return esc ? m : `\\${m}`;
     });
 
     if (backslashes === true) {
@@ -395,11 +395,11 @@ const parse = (input, options) => {
       }
 
       if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
-        value = '\\' + value;
+        value = `\\${value}`;
       }
 
       if (value === ']' && (prev.value === '[' || prev.value === '[^')) {
-        value = '\\' + value;
+        value = `\\${value}`;
       }
 
       if (opts.posix === true && value === '!' && prev.value === '[') {
@@ -471,7 +471,7 @@ const parse = (input, options) => {
           throw new SyntaxError(syntaxError('closing', ']'));
         }
 
-        value = '\\' + value;
+        value = `\\${value}`;
       } else {
         increment('brackets');
       }
@@ -482,7 +482,7 @@ const parse = (input, options) => {
 
     if (value === ']') {
       if (opts.nobracket === true || (prev && prev.type === 'bracket' && prev.value.length === 1)) {
-        push({ type: 'text', value, output: '\\' + value });
+        push({ type: 'text', value, output: `\\${value}` });
         continue;
       }
 
@@ -491,7 +491,7 @@ const parse = (input, options) => {
           throw new SyntaxError(syntaxError('opening', '['));
         }
 
-        push({ type: 'text', value, output: '\\' + value });
+        push({ type: 'text', value, output: `\\${value}` });
         continue;
       }
 
@@ -499,7 +499,7 @@ const parse = (input, options) => {
 
       const prevValue = prev.value.slice(1);
       if (prev.posix !== true && prevValue[0] === '^' && !prevValue.includes('/')) {
-        value = '/' + value;
+        value = `/${value}`;
       }
 
       prev.value += value;
@@ -661,7 +661,7 @@ const parse = (input, options) => {
         }
 
         if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
-          output = '\\' + value;
+          output = `\\${value}`;
         }
 
         push({ type: 'text', value, output });
@@ -739,7 +739,7 @@ const parse = (input, options) => {
 
     if (value !== '*') {
       if (value === '$' || value === '^') {
-        value = '\\' + value;
+        value = `\\${value}`;
       }
 
       const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
@@ -816,7 +816,7 @@ const parse = (input, options) => {
 
       if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
         state.output = state.output.slice(0, -(prior.output + prev.output).length);
-        prior.output = '(?:' + prior.output;
+        prior.output = `(?:${prior.output}`;
 
         prev.type = 'globstar';
         prev.output = globstar(opts) + (opts.strictSlashes ? ')' : '|$)');
@@ -831,7 +831,7 @@ const parse = (input, options) => {
         const end = rest[1] !== void 0 ? '|$' : '';
 
         state.output = state.output.slice(0, -(prior.output + prev.output).length);
-        prior.output = '(?:' + prior.output;
+        prior.output = `(?:${prior.output}`;
 
         prev.type = 'globstar';
         prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,7 @@ exports.escapeLast = (input, char, lastIdx) => {
   const idx = input.lastIndexOf(char, lastIdx);
   if (idx === -1) return input;
   if (input[idx - 1] === '\\') return exports.escapeLast(input, char, idx - 1);
-  return input.slice(0, idx) + '\\' + input.slice(idx);
+  return `${input.slice(0, idx)}\\${input.slice(idx)}`;
 };
 
 exports.removePrefix = (input, state = {}) => {


### PR DESCRIPTION
Would be nice to have a benchmark before merging this :)

Also, if we go with this, we should eventually update the ESLint config to check for the modern features (`prefer-*` rules).