### PR TITLE
Disable fastpaths mode for the parse method

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -189,7 +189,10 @@ picomatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str
  * @api public
  */
 
-picomatch.parse = (glob, options) => parse(glob, options);
+picomatch.parse = (glob, options) => parse(glob, {
+  ...options,
+  fastpaths: false
+});
 
 /**
  * Scan a glob pattern to separate the pattern into segments.

--- a/test/api.picomatch.js
+++ b/test/api.picomatch.js
@@ -4,6 +4,12 @@ const assert = require('assert');
 const picomatch = require('..');
 const { isMatch } = picomatch;
 
+const assertTokens = (actual, expected) => {
+  const keyValuePairs = actual.map((token) => [token.type, token.value]);
+
+  assert.deepStrictEqual(keyValuePairs, expected);
+};
+
 describe('picomatch', () => {
   describe('validation', () => {
     it('should throw an error when invalid arguments are given', () => {
@@ -305,6 +311,40 @@ describe('picomatch', () => {
       assert(isMatch('.c.md', '.*', { dot: true }));
       assert(isMatch('a/b/c/.xyz.md', 'a/b/c/*.md', { dot: true }));
       assert(isMatch('a/b/c/.xyz.md', 'a/b/c/.*.md', { dot: true }));
+    });
+  });
+
+  describe('.parse', () => {
+    describe('tokens', () => {
+      it('should return result for pattern that matched by fastpath', () => {
+        const { tokens } = picomatch.parse('a*.txt');
+
+        const expected = [
+          ['bos', ''],
+          ['text', 'a'],
+          ['star', '*'],
+          ['text', '.txt']
+        ];
+
+        assertTokens(tokens, expected);
+      });
+
+      it('should return result for pattern', () => {
+        const { tokens } = picomatch.parse('{a,b}*');
+
+        const expected = [
+          ['bos', ''],
+          ['brace', '{'],
+          ['text', 'a'],
+          ['comma', ','],
+          ['text', 'b'],
+          ['brace', '}'],
+          ['star', '*'],
+          ['maybe_slash', '']
+        ];
+
+        assertTokens(tokens, expected);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR disables the `fastpaths` mode for the `parse` method. The main reason is that when the mode is enabled, no tokens are returned for the some patterns like `a*.txt`:

**Before**

```js
var picomatch = require("picomatch");

console.log(picomatch.parse('a*.txt').tokens);

// [Object {output: "", type: "bos", value: ""}]
```

**After**

```js
var picomatch = require("picomatch");

console.log(picomatch.parse('a*.txt', { fastpaths: false }).tokens);

// Array (4 items)
// 0: Object {output: "", type: "bos", value: ""}
// 1: Object {prev: Object {output: "", type: "bos", value: ""}, type: "text", value: "a"}
// 2: Object {output: "[^/]*?", …}
// 3: Object {output: "\\.", …}
// Array Prototype
```

The `parse` method must always return tokens, otherwise it makes no sense.