### PR TITLE
Do not use previous value for the slash token

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -840,7 +840,7 @@ const parse = (input, options) => {
         state.output += prior.output + prev.output;
         consume(value + advance());
 
-        push({ type: 'slash', value, output: '' });
+        push({ type: 'slash', value: '/', output: '' });
         continue;
       }
 
@@ -850,7 +850,7 @@ const parse = (input, options) => {
         prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
         state.output = prev.output;
         consume(value + advance());
-        push({ type: 'slash', value, output: '' });
+        push({ type: 'slash', value: '/', output: '' });
         continue;
       }
 


### PR DESCRIPTION
For some patterns the `.parse` method returns tokens with correct type but wrong value.

```js
// a/b/**/
[
  [ 'bos', '' ],
  [ 'text', 'a' ],
  [ 'slash', '/' ],
  [ 'text', 'b' ],
  [ 'slash', '/' ],
  [ 'globstar', '**' ],
  [ 'slash', '*' ] // <------------- * — before, / — after
]

// **/a
[
  [ 'bos', '' ],
  [ 'globstar', '**' ],
  [ 'slash', '*' ], // <------------ * — before, / — after
  [ 'text', 'a' ]
]
```

I don't know where I must write tests for it :)