### PR TITLE
use parse function directly

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -256,7 +256,7 @@ picomatch.makeRe = (input, options, returnOutput = false, returnState = false) =
   }
 
   if (output === void 0) {
-    state = picomatch.parse(input, options);
+    state = parse(input, options);
     state.prefix = prefix + (state.prefix || '');
     output = state.output;
   }


### PR DESCRIPTION
I noticed that the code coverage decreased with #51. This PR uses the `parse` function directly internally, which increases code coverage.