### PR TITLE
ISSUE-58: Correctly handle a part after parentheses

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -247,23 +247,24 @@ const scan = (input, options) => {
     }
 
     if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
-      while (eos() !== true && (code = advance())) {
-        if (code === CHAR_BACKWARD_SLASH) {
-          backslashes = token.backslashes = true;
-          code = advance();
-          continue;
-        }
+      isGlob = token.isGlob = true;
 
-        if (code === CHAR_RIGHT_PARENTHESES) {
-          isGlob = token.isGlob = true;
-          finished = true;
-
-          if (scanToEnd === true) {
+      if (scanToEnd === true) {
+        while (eos() !== true && (code = advance())) {
+          if (code === CHAR_LEFT_PARENTHESES) {
+            backslashes = token.backslashes = true;
+            code = advance();
             continue;
           }
-          break;
+
+          if (code === CHAR_RIGHT_PARENTHESES) {
+            finished = true;
+            break;
+          }
         }
+        continue;
       }
+      break;
     }
 
     if (isGlob === true) {

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -288,9 +288,6 @@ describe('picomatch', () => {
       // Right now it returns ['*']
       // assertParts('*/', ['*', '']);
 
-      // Right now it returns ['foo', '(bar|baz)']
-      // assertParts('foo/(bar|baz)/*.js', ['foo', '(bar|baz)', '*.js']);
-
       // Right now it returns ['!(!(bar)', 'baz)']
       // assertParts('!(!(bar)/baz)', ['!(!(bar)/baz)']);
 
@@ -310,6 +307,7 @@ describe('picomatch', () => {
       assertParts('foo/(bar|baz)*', ['foo', '(bar|baz)*']);
       assertParts('**/*(W*, *)*', ['**', '*(W*, *)*']);
       assertParts('a/**@(/x|/z)/*.md', ['a', '**@(/x|/z)', '*.md']);
+      assertParts('foo/(bar|baz)/*.js', ['foo', '(bar|baz)', '*.js']);
 
       assertParts('XXX/*/*/12/*/*/m/*/*', ['XXX', '*', '*', '12', '*', '*', 'm', '*', '*']);
       assertParts('foo/\\"**\\"/bar', ['foo', '\\"**\\"', 'bar']);

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -9,6 +9,16 @@ const both = (...args) => {
 };
 
 /**
+ * @param {String} pattern
+ * @param {String[]} parts
+ */
+function assertParts(pattern, parts) {
+  const info = scan(pattern, { parts: true });
+
+  assert.deepStrictEqual(info.parts, parts);
+}
+
+/**
  * Most of the unit tests in this file were from https://github.com/es128/glob-parent
  * and https://github.com/jonschlinkert/glob-base. Both libraries use a completely
  * different approach to separating the glob pattern from the "path" from picomatch,
@@ -251,6 +261,58 @@ describe('picomatch', () => {
         isExtglob: false,
         negated: false
       });
+    });
+
+    it('should return parts of the pattern', () => {
+      // Right now it returns []
+      // assertParts('', ['']);
+      // assertParts('*', ['*']);
+      // assertParts('.*', ['.*']);
+      // assertParts('**', ['**']);
+      // assertParts('foo', ['foo']);
+      // assertParts('foo*', ['foo*']);
+      // assertParts('/', ['', '']);
+      // assertParts('/*', ['', '*']);
+      // assertParts('./', ['']);
+      // assertParts('{1..9}', ['{1..9}']);
+      // assertParts('c!(.)z', ['c!(.)z']);
+      // assertParts('(b|a).(a)', ['(b|a).(a)']);
+      // assertParts('+(a|b\\[)*', ['+(a|b\\[)*']);
+      // assertParts('@(a|b).md', ['@(a|b).md']);
+      // assertParts('(a/b)', ['(a/b)']);
+      // assertParts('(a\\b)', ['(a\\b)']);
+      // assertParts('foo\\[a\\/]', ['foo\\[a\\/]']);
+      // assertParts('foo[/]bar', ['foo[/]bar']);
+      // assertParts('/dev\\/@(tcp|udp)\\/*\\/*', ['', '/dev\\/@(tcp|udp)\\/*\\/*']);
+
+      // Right now it returns ['*']
+      // assertParts('*/', ['*', '']);
+
+      // Right now it returns ['foo', '(bar|baz)']
+      // assertParts('foo/(bar|baz)/*.js', ['foo', '(bar|baz)', '*.js']);
+
+      // Right now it returns ['!(!(bar)', 'baz)']
+      // assertParts('!(!(bar)/baz)', ['!(!(bar)/baz)']);
+
+      assertParts('./foo', ['foo']);
+      assertParts('../foo', ['..', 'foo']);
+
+      assertParts('foo/bar', ['foo', 'bar']);
+      assertParts('foo/*', ['foo', '*']);
+      assertParts('foo/**', ['foo', '**']);
+      assertParts('foo/**/*', ['foo', '**', '*']);
+      assertParts('フォルダ/**/*', ['フォルダ', '**', '*']);
+
+      assertParts('foo/!(abc)', ['foo', '!(abc)']);
+      assertParts('c/!(z)/v', ['c', '!(z)', 'v']);
+      assertParts('c/@(z)/v', ['c', '@(z)', 'v']);
+      assertParts('foo/(bar|baz)', ['foo', '(bar|baz)']);
+      assertParts('foo/(bar|baz)*', ['foo', '(bar|baz)*']);
+      assertParts('**/*(W*, *)*', ['**', '*(W*, *)*']);
+      assertParts('a/**@(/x|/z)/*.md', ['a', '**@(/x|/z)', '*.md']);
+
+      assertParts('XXX/*/*/12/*/*/m/*/*', ['XXX', '*', '*', '12', '*', '*', 'm', '*', '*']);
+      assertParts('foo/\\"**\\"/bar', ['foo', '\\"**\\"', 'bar']);
     });
   });
 


### PR DESCRIPTION
This is a partial fix of #58. Source for this case is https://github.com/mrmlnc/fast-glob/issues/263.

Changes:

* Add some tests for the `scan` method; I tried to collect all the edge cases.
* Correctly handle a case with a part after parentheses. E.g. `base/(a|b)/*.js`

I'm not sure how to test this correctly. Changes based on `extglob` support:

https://github.com/micromatch/picomatch/blob/66e1b200f3ea1784bdeae0770c8e5cd95f55e334/lib/scan.js#L169-L199.