### PR TITLE
Special character typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ If you wish to match the following special characters in a filepath, and you wan
 
 Some characters that are used for matching in regular expressions are also regarded as valid file path characters on some platforms.
 
-To match any of the following characters as literals: `$^*+?()[]
+To match any of the following characters as literals: `$^*+?()[]`
 
 Examples:
 


### PR DESCRIPTION
Not sure if this is worth a PR, but the backtick is not a special character in `picomatch` nor regular regex and attempting to escape it is going to cause some problems.