### PR TITLE
Do not skip segment separator for square brackets

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -231,13 +231,15 @@ const scan = (input, options) => {
           isBracket = token.isBracket = true;
           isGlob = token.isGlob = true;
           finished = true;
-
-          if (scanToEnd === true) {
-            continue;
-          }
           break;
         }
       }
+
+      if (scanToEnd === true) {
+        continue;
+      }
+
+      break;
     }
 
     if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -311,6 +311,10 @@ describe('picomatch', () => {
 
       assertParts('XXX/*/*/12/*/*/m/*/*', ['XXX', '*', '*', '12', '*', '*', 'm', '*', '*']);
       assertParts('foo/\\"**\\"/bar', ['foo', '\\"**\\"', 'bar']);
+
+      assertParts('[0-9]/[0-9]', ['[0-9]', '[0-9]']);
+      assertParts('foo/[0-9]/[0-9]', ['foo', '[0-9]', '[0-9]']);
+      assertParts('foo[0-9]/bar[0-9]', ['foo[0-9]', 'bar[0-9]']);
     });
   });
 


### PR DESCRIPTION
#### Links

https://github.com/mrmlnc/fast-glob/issues/295

#### Current behavior

Before this PR.

```js
picomatch.scan('foo/[0-9]/[0-9]', { parts: true }) → ['foo', '[0-9]/[0-9]']
```

#### Expected behavior

With this PR. Changes based on `CHAR_RIGHT_CURLY_BRACE` case.

```js
picomatch.scan('foo/[0-9]/[0-9]', { parts: true }) → ['foo', '[0-9]', '[0-9]']
```