### PR TITLE
feat: Add new `negatedExtglob` state to result of scan

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -32,7 +32,8 @@ const depth = token => {
 /**
  * Quickly scans a glob pattern and returns an object with a handful of
  * useful properties, like `isGlob`, `path` (the leading non-glob, if it exists),
- * `glob` (the actual pattern), and `negated` (true if the path starts with `!`).
+ * `glob` (the actual pattern), `negated` (true if the path starts with `!` but not
+ * with `!(`) and `negatedExtglob` (true if the path starts with `!(`).
  *
  * ```js
  * const pm = require('picomatch');
@@ -66,6 +67,7 @@ const scan = (input, options) => {
   let braceEscaped = false;
   let backslashes = false;
   let negated = false;
+  let negatedExtglob = false;
   let finished = false;
   let braces = 0;
   let prev;
@@ -177,6 +179,9 @@ const scan = (input, options) => {
         isGlob = token.isGlob = true;
         isExtglob = token.isExtglob = true;
         finished = true;
+        if (code === CHAR_EXCLAMATION_MARK && index === start) {
+          negatedExtglob = true;
+        }
 
         if (scanToEnd === true) {
           while (eos() !== true && (code = advance())) {
@@ -330,7 +335,8 @@ const scan = (input, options) => {
     isGlob,
     isExtglob,
     isGlobstar,
-    negated
+    negated,
+    negatedExtglob
   };
 
   if (opts.tokens === true) {

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -47,7 +47,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -63,7 +64,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -79,7 +81,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: true,
         isExtglob: false,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -95,7 +98,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: true,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -112,6 +116,7 @@ describe('picomatch', () => {
         isGlobstar: true,
         isExtglob: true,
         negated: false,
+        negatedExtglob: false,
         slashes: [1, 5, 12, 15],
         parts: ['foo', '@(bar)', '**', '*.js']
       });
@@ -129,7 +134,57 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: true
+        negated: true,
+        negatedExtglob: false
+      });
+    });
+
+    it('should detect negated extglobs at the begining', () => {
+      assert.deepStrictEqual(scan('!(foo)*'), {
+        input: '!(foo)*',
+        prefix: '',
+        start: 0,
+        base: '',
+        glob: '!(foo)*',
+        isBrace: false,
+        isBracket: false,
+        isGlob: true,
+        isGlobstar: false,
+        isExtglob: true,
+        negated: false,
+        negatedExtglob: true
+      });
+
+      assert.deepStrictEqual(scan('!(foo)'), {
+        input: '!(foo)',
+        prefix: '',
+        start: 0,
+        base: '',
+        glob: '!(foo)',
+        isBrace: false,
+        isBracket: false,
+        isGlob: true,
+        isGlobstar: false,
+        isExtglob: true,
+        negated: false,
+        negatedExtglob: true
+      });
+    });
+
+    it('should not detect negated extglobs in the middle', () => {
+      assert.deepStrictEqual(scan('test/!(foo)/*'), {
+        input: 'test/!(foo)/*',
+        prefix: '',
+        start: 0,
+        base: 'test',
+        glob: '!(foo)/*',
+        isBrace: false,
+        isBracket: false,
+        isGlob: true,
+        isGlobstar: false,
+        isExtglob: true,
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -145,7 +200,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: true
+        negated: true,
+        negatedExtglob: false
       });
 
       assert.deepStrictEqual(scan('!./foo/bar/*.js'), {
@@ -159,7 +215,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: true
+        negated: true,
+        negatedExtglob: false
       });
     });
 
@@ -243,7 +300,8 @@ describe('picomatch', () => {
         isGlob: false,
         isGlobstar: false,
         isExtglob: false,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 
@@ -259,7 +317,8 @@ describe('picomatch', () => {
         isGlob: true,
         isGlobstar: false,
         isExtglob: false,
-        negated: false
+        negated: false,
+        negatedExtglob: false
       });
     });
 


### PR DESCRIPTION
This allows consumers to see if the glob starts with a negated extglob similar to parse.
At first I wondered if this should maybe set negated to true, but that might be a breaking change and also is then completely different from parse.


One example is jest which uses `scan` and `matcher` to mimic micromatchs main api. https://github.com/facebook/jest/blob/d49cb30fb2540efa8c451fb6cb24e8997284bc67/packages/jest-util/src/globsToMatcher.ts#L49-L52

This makes it possible to solve this issue micromatch/micromatch#179 in jest as well as basically support all negated extglobs as non of them work correctly atm.

