### PR TITLE
chore: simplify `REGEX_REMOVE_BACKSLASH`

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -93,7 +93,7 @@ module.exports = {
   REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
   REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
   REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
-  REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+  REGEX_REMOVE_BACKSLASH: /\[.*?[^\\]]|\\(?=.)/g,
 
   // Replace globs with equivalent patterns to reduce parsing time.
   REPLACEMENTS: {


### PR DESCRIPTION
This is where the polynomial execution happens; this doesn't fix the issue, but I noticed it could be simplified.

Perhaps this rings a bell to whoever wrote the regex in the first place?