### PR TITLE
ISSUE-93: support stars in negation extglobs with expression after closing parenthesis

### DIFF
--- a/test/extglobs.js
+++ b/test/extglobs.js
@@ -58,13 +58,32 @@ describe('extglobs', () => {
     it('should support stars in negation extglobs', () => {
       assert(!isMatch('/file.d.ts', '/!(*.d).ts'));
       assert(isMatch('/file.ts', '/!(*.d).ts'));
+      assert(isMatch('/file.something.ts', '/!(*.d).ts'));
       assert(isMatch('/file.d.something.ts', '/!(*.d).ts'));
       assert(isMatch('/file.dhello.ts', '/!(*.d).ts'));
 
       assert(!isMatch('/file.d.ts', '**/!(*.d).ts'));
       assert(isMatch('/file.ts', '**/!(*.d).ts'));
+      assert(isMatch('/file.something.ts', '**/!(*.d).ts'));
       assert(isMatch('/file.d.something.ts', '**/!(*.d).ts'));
       assert(isMatch('/file.dhello.ts', '**/!(*.d).ts'));
+    });
+
+    // See https://github.com/micromatch/picomatch/issues/93
+    it('should support stars in negation extglobs with expression after closing parenthesis', () => {
+      // Nested expression after closing parenthesis
+      assert(!isMatch('/file.d.ts', '/!(*.d).{ts,tsx}'));
+      assert(isMatch('/file.ts', '/!(*.d).{ts,tsx}'));
+      assert(isMatch('/file.something.ts', '/!(*.d).{ts,tsx}'));
+      assert(isMatch('/file.d.something.ts', '/!(*.d).{ts,tsx}'));
+      assert(isMatch('/file.dhello.ts', '/!(*.d).{ts,tsx}'));
+
+      // Extglob after closing parenthesis
+      assert(!isMatch('/file.d.ts', '/!(*.d).@(ts)'));
+      assert(isMatch('/file.ts', '/!(*.d).@(ts)'));
+      assert(isMatch('/file.something.ts', '/!(*.d).@(ts)'));
+      assert(isMatch('/file.d.something.ts', '/!(*.d).@(ts)'));
+      assert(isMatch('/file.dhello.ts', '/!(*.d).@(ts)'));
     });
 
     it('should support negation extglobs in patterns with slashes', () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This is a fix for #93.

#### What changes did you make? (Give an overview)

Please read the comment in the code. More context of the suggested solution is [here](https://github.com/micromatch/picomatch/issues/93#issuecomment-1003734593).