### PR TITLE
Make matchBase only apply to patterns without slashes

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -134,7 +134,7 @@ picomatch.test = (input, regex, options, { glob, posix } = {}) => {
   }
 
   if (match === false || opts.capture === true) {
-    if (opts.matchBase === true || opts.basename === true) {
+    if (!glob.includes('/') && (opts.matchBase === true || opts.basename === true)) {
       match = picomatch.matchBase(input, regex, options, posix);
     } else {
       match = regex.exec(output);

--- a/test/options.js
+++ b/test/options.js
@@ -22,8 +22,15 @@ describe('options', () => {
     it('should work with negation patterns', () => {
       assert(isMatch('./x/y.js', '*.js', { matchBase: true }));
       assert(!isMatch('./x/y.js', '!*.js', { matchBase: true }));
-      assert(isMatch('./x/y.js', '**/*.js', { matchBase: true }));
-      assert(!isMatch('./x/y.js', '!**/*.js', { matchBase: true }));
+    });
+
+    it('should not affect patterns with slashes', () => {
+      assert(isMatch('x/y.js', 'x/**'));
+      assert(isMatch('x/y.js', 'x/**', { matchBase: true }));
+      assert(isMatch('x/y.js', '**/*.js'));
+      assert(isMatch('x/y.js', '**/*.js', { matchBase: true }));
+      assert(!isMatch('x/y.js', '!**/*.js'));
+      assert(!isMatch('x/y.js', '!**/*.js', { matchBase: true }));
     });
   });
 


### PR DESCRIPTION
This is the documented behavior of micromatch.

Fixes #89