### PR TITLE
fix bad `text` values in `parse`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -209,8 +209,8 @@ const parse = (input, options) => {
 
     if (tok.value || tok.output) append(tok);
     if (prev && prev.type === 'text' && tok.type === 'text') {
+      prev.output = (prev.output || prev.value) + tok.value;
       prev.value += tok.value;
-      prev.output = (prev.output || '') + tok.value;
       return;
     }
 

--- a/test/api.picomatch.js
+++ b/test/api.picomatch.js
@@ -345,6 +345,22 @@ describe('picomatch', () => {
 
         assertTokens(tokens, expected);
       });
+
+      it('pictomatch issue#125, issue#100', () => {
+        const { tokens } = picomatch.parse('foo.(m|c|)js');
+
+        const expected = [
+          ['bos', { output: '', value: '' }],
+          ['text', { output: 'foo.', value: 'foo.' }],
+          ['paren', { output: undefined, value: '(' }],
+          ['text', { output: 'm|c|', value: 'm|c|' }],
+          ['paren', { output: ')', value: ')' }],
+          ['text', { output: undefined, value: 'js' }]
+        ];
+
+        const keyValuePairs = tokens.map(token => [token.type, { output: token.output, value: token.value }]);
+        assert.deepStrictEqual(keyValuePairs, expected);
+      });
     });
   });
 


### PR DESCRIPTION
Previously sibling `text` tokens would exclude the `output` from the first token, resulting in the referenced issues. I think this should be a fairly safe change.

Fixes #125
Fixes #100