### PR TITLE
Add sideEffects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "posix.js",
     "lib"
   ],
+  "sideEffects": false,
   "main": "index.js",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Hi 👋 
Bundlers like Webpack or ESBuild use the key `sideEffects` in package.json to [enhance tree-shaking](https://webpack.js.org/guides/tree-shaking/) in some conditions.
I noticed picomatch is unnecessarily bundled when using the [new ViteRuntime](https://github.com/vitejs/vite/pull/12165) and, as a result, its calls to `require` make the code fail in certain environments.

The current workarounds look like [this](https://github.com/Shopify/hydrogen/blob/dbbf9c5f72c12cd65598d14abf341fc7393da1d0/packages/cli/tsup.config.ts#L64). This change should fix that.