### PR TITLE
feat!: remove process global to work outside of node

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -698,10 +698,6 @@ const parse = (input, options) => {
         const next = peek();
         let output = value;
 
-        if (next === '<' && !utils.supportsLookbehinds()) {
-          throw new Error('Node.js v10 or higher is required for regex lookbehinds');
-        }
-
         if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
           output = `\\${value}`;
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,16 +19,6 @@ exports.removeBackslashes = str => {
   });
 };
 
-exports.supportsLookbehinds = () => {
-  if (typeof process !== 'undefined') {
-    const segs = process.version.slice(1).split('.').map(Number);
-    if (segs.length === 3 && segs[0] >= 9 || (segs[0] === 8 && segs[1] >= 10)) {
-      return true;
-    }
-  }
-  return false;
-};
-
 exports.escapeLast = (input, char, lastIdx) => {
   const idx = input.lastIndexOf(char, lastIdx);
   if (idx === -1) return input;

--- a/test/regex-features.js
+++ b/test/regex-features.js
@@ -18,12 +18,10 @@ describe('regex features', () => {
 
   describe('regex lookarounds', () => {
     it('should support regex lookbehinds', () => {
-      if (utils.supportsLookbehinds()) {
-        assert(isMatch('foo/cbaz', 'foo/*(?<!d)baz'));
-        assert(!isMatch('foo/cbaz', 'foo/*(?<!c)baz'));
-        assert(!isMatch('foo/cbaz', 'foo/*(?<=d)baz'));
-        assert(isMatch('foo/cbaz', 'foo/*(?<=c)baz'));
-      }
+      assert(isMatch('foo/cbaz', 'foo/*(?<!d)baz'));
+      assert(!isMatch('foo/cbaz', 'foo/*(?<!c)baz'));
+      assert(!isMatch('foo/cbaz', 'foo/*(?<=d)baz'));
+      assert(isMatch('foo/cbaz', 'foo/*(?<=c)baz'));
     });
 
     it('should throw an error when regex lookbehinds are used on an unsupported node version', () => {

--- a/test/regex-features.js
+++ b/test/regex-features.js
@@ -23,13 +23,6 @@ describe('regex features', () => {
       assert(!isMatch('foo/cbaz', 'foo/*(?<=d)baz'));
       assert(isMatch('foo/cbaz', 'foo/*(?<=c)baz'));
     });
-
-    it('should throw an error when regex lookbehinds are used on an unsupported node version', () => {
-      const nodeMajor = process.versions.node.split('.')[0];
-      if (nodeMajor < 10) {
-        assert.throws(() => isMatch('foo/cbaz', 'foo/*(?<!c)baz'), /Node\.js v10 or higher/);
-      }
-    });
   });
 
   describe('regex back-references', () => {

--- a/test/regex-features.js
+++ b/test/regex-features.js
@@ -25,9 +25,10 @@ describe('regex features', () => {
     });
 
     it('should throw an error when regex lookbehinds are used on an unsupported node version', () => {
-      Reflect.defineProperty(process, 'version', { value: 'v6.0.0' });
-      assert.throws(() => isMatch('foo/cbaz', 'foo/*(?<!c)baz'), /Node\.js v10 or higher/);
-      Reflect.defineProperty(process, 'version', { value: version });
+      const nodeMajor = process.versions.node.split('.')[0];
+      if (nodeMajor < 10) {
+        assert.throws(() => isMatch('foo/cbaz', 'foo/*(?<!c)baz'), /Node\.js v10 or higher/);
+      }
     });
   });
 


### PR DESCRIPTION
In order to support more JS runtimes besides Node.js, this PR drops the check for `process` global.

The `process` global was only used to improve the error message for Node.js less than 10 (released April 2018).

This could be considered a breaking change since the error message will change, however this package already specifies package.json `engines.node` with `>=10`, so perhaps no one can even run it on older versions of Node.js without an install error.

https://github.com/micromatch/picomatch/blob/5214db489eb118db1bcfde39f446188757bb45cf/package.json#L20

- Related to https://github.com/micromatch/picomatch/issues/123