### PR TITLE
fix: Replacements

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1004,7 +1004,9 @@ parse.fastpaths = (input, options) => {
     throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
   }
 
-  input = REPLACEMENTS[input] || input;
+  if (REPLACEMENTS.hasOwnProperty(input)) {
+    input = REPLACEMENTS[input];
+  }
 
   // create constants based on platform, for windows or posix
   const {


### PR DESCRIPTION
Hello, I found an interesting bug while i was working with pcss library. The pcss was broken only for me, while same project runs without problem for my collegs. While investigeting it, I found out the problem, my path to project was: "/projects/constructor/project_name", and this constructor name was the problem. Because if you call REPLACEMENTS['constructor'] it will return the function.