### PR TITLE
Allow `isIgnored` to un-ignore results by returning token

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,7 @@
     "no-irregular-whitespace": 2,
     "no-iterator": 2,
     "no-label-var": 2,
-    "no-labels": 2,
+    "no-labels": 0,
     "no-lone-blocks": 2,
     "no-lonely-if": 2,
     "no-mixed-spaces-and-tabs": 2,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         node: [12, 14, 16, 18, 20, 21]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          - os: macOS-latest
+            node: 12
+          - os: macOS-latest
+            node: 14
 
     steps:
       - name: Clone repository

--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ isMatch('bar');
 isMatch('baz');
 ```
 
+Return `picomatch.constants.UNIGNORE` from `onIgnore` to un-ignore the result.
+
 #### options.onResult
 
 ```js

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,8 @@
 const WIN_SLASH = '\\\\/';
 const WIN_NO_SLASH = `[^${WIN_SLASH}]`;
 
+const UNIGNORE = Symbol('unignore');
+
 /**
  * Posix glob regex
  */
@@ -88,6 +90,9 @@ const POSIX_REGEX_SOURCE = {
 module.exports = {
   MAX_LENGTH: 1024 * 64,
   POSIX_REGEX_SOURCE,
+
+  // token to un-ignore results in onIgnore
+  UNIGNORE,
 
   // regular expressions
   REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,

--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -75,12 +75,17 @@ const picomatch = (glob, options, returnState = false) => {
       return returnObject ? result : false;
     }
 
-    if (isIgnored(input)) {
-      if (typeof opts.onIgnore === 'function') {
-        opts.onIgnore(result);
+    ignored: {
+      if (isIgnored(input)) {
+        if (typeof opts.onIgnore === 'function') {
+          if (opts.onIgnore(result) === constants.UNIGNORE) {
+            result.isMatch = true;
+            break ignored;
+          }
+        }
+        result.isMatch = false;
+        return returnObject ? result : false;
       }
-      result.isMatch = false;
-      return returnObject ? result : false;
     }
 
     if (typeof opts.onMatch === 'function') {

--- a/test/options.onIgnore.js
+++ b/test/options.onIgnore.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('assert');
+const match = require('./support/match');
+const picomatch = require('..');
+const { isMatch } = picomatch;
+
+const equal = (actual, expected, msg) => {
+  assert.deepStrictEqual([].concat(actual).sort(), [].concat(expected).sort(), msg);
+};
+
+describe('options.onIgnore', () => {
+  it('should call options.onIgnore on each ignored string', () => {
+    const ignored = [];
+
+    const options = {
+      ignore: ['b/*', 'b/*/*'],
+      onIgnore({ pattern, regex, input, output }) {
+        ignored.push(input);
+      }
+    };
+
+    const fixtures = ['a', 'b', 'b/a', 'b/b', 'b/a/a'];
+
+    equal(match(fixtures, '**', options), ['a', 'b']);
+    equal(ignored.length, 3);
+  });
+
+  it('should allow to un-ignore from options.onIgnore', () => {
+    const options = (ignore, unignore) => {
+      return {
+        ignore,
+        onIgnore({ pattern, regex, input, output }) {
+          if (unignore) return isMatch(input, unignore) && picomatch.constants.UNIGNORE;
+        }
+      };
+    };
+
+    const fixtures = ['a', 'b', 'b/a', 'b/b', 'b/a/a'];
+
+    equal(match(fixtures, '**', options(['b/*', 'b/*/*'])), ['a', 'b']);
+    equal(match(fixtures, '**', options(['b/*', 'b/*/*'], ['b/a'])), ['a', 'b', 'b/a']);
+    equal(match(fixtures, '**', options(['b/*', 'b/*/*'], ['b/a/a'])), ['a', 'b', 'b/a/a']);
+    equal(match(fixtures, '**', options(['b/*', 'b/*/*'], ['b/*'])), ['a', 'b', 'b/a', 'b/b']);
+    equal(match(fixtures, '**', options(['b/*', 'b/*/*'], ['*/a'])), ['a', 'b', 'b/a']);
+    equal(match(fixtures, '**', options([], ['**'])), ['a', 'b', 'b/a', 'b/b', 'b/a/a']);
+  });
+
+  it('should call onMatch for un-ignored results', () => {
+    const patterns = [];
+
+    const options = (ignore, unignore) => {
+      return {
+        ignore,
+        onIgnore({ pattern, regex, input, output }) {
+          if (unignore) return isMatch(input, unignore) && picomatch.constants.UNIGNORE;
+        },
+        onMatch({ pattern, regex, input, output }, matches) {
+          patterns.push(output);
+        }
+      };
+    };
+
+    const fixtures = ['a', 'b', 'b/a', 'b/b', 'b/a/a'];
+
+    equal(match(fixtures, '**', options(['b/a**'], ['b/a/a'])), ['a', 'b', 'b/b', 'b/a/a']);
+    equal(patterns, ['a', 'b', 'b/b', 'b/a/a']);
+  });
+});


### PR DESCRIPTION
Making the case for negated ignore patterns.

Glob libraries like fast-glob, node-glob and tinyglobby use the `ignore` option to exclude matches from the results. Yet there's also a case to be made to un-ignore such results. For instance, when `.gitignore` files should be taken into account.

Let's say we have the following

```
.
├── index.js
└── .yarn
    ├── plugins
    │   └── my-plugin.js
    └── index.js
```

Or just

```
index.js
.yarn/plugins/my-plugin.js
.yarn/index.js
```

Projects may have files like `.gitignore` (or other ignore files) like so:

```
**/.yarn/*
!.yarn/releases
!.yarn/plugins
!.yarn/sdks
!.yarn/versions
```

The semantics of `.gitignore` items differ from glob patterns, but let's _ignore_ that here, not picomatch's problem.

What downstream packages might want to do is take such patterns into account like this:

```ts
picomatch("**/*.js", {
  ignore: ["**/.yarn/**", "!.yarn/plugins"]
});
```

There's currently just no feasible way to make the negated items from `.gitignore` slip through.

So that's where this PR comes in. We can filter out the negated patterns and:

```ts
const unignores = [".yarn/plugins"];

picomatch("**/*.js", {
  ignore: ["**/.yarn/**"],
  onUnignore: ({input} => isMatch(input, unignores) && picomatch.constants.UNIGNORE;
});
```

By returning the token, the item is un-ignored and slips through. The implementation of `onUnignore` should be optimized, this is just an example to illustrate the idea.

A solution like this with a token is guaranteed to be a non-breaking change. An alternative I thought of first would be to simply return `true` which would _probably_ also not be a breaking change, but it's not guaranteed.

Relevant issues:

- https://github.com/mrmlnc/fast-glob/issues/86
- https://github.com/isaacs/node-glob/issues/409
- https://github.com/SuperchupuDev/tinyglobby/issues/32

Part of why [globby](https://github.com/sindresorhus/globby) got so popular is because of it's support for `.gitignore` files, but the implementation is rather tedious and slow. Solving this in picomatch directly would be a major advantage in terms of both simplicity and performance.

I think the implementation is relatively clean and low-impact while non-breaking. Needless to say I'm open to suggestion to improve if you have any!