### PR TITLE
fix: exception when glob pattern contains `constructor`

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -98,11 +98,11 @@ module.exports = {
   REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
 
   // Replace globs with equivalent patterns to reduce parsing time.
-  REPLACEMENTS: {
+  REPLACEMENTS: Object.assign(Object.create(null), {
     '***': '*',
     '**/**': '**',
     '**/**/**': '**'
-  },
+  }),
 
   // Digits
   CHAR_0: 48, /* 0 */

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -98,7 +98,7 @@ module.exports = {
   REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
 
   // Replace globs with equivalent patterns to reduce parsing time.
-  REPLACEMENTS: Object.assign(Object.create(null), {
+  REPLACEMENTS: Object.create(null, {
     '***': '*',
     '**/**': '**',
     '**/**/**': '**'

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -98,11 +98,12 @@ module.exports = {
   REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
 
   // Replace globs with equivalent patterns to reduce parsing time.
-  REPLACEMENTS: Object.create(null, {
+  REPLACEMENTS: {
+    __proto__: null,
     '***': '*',
     '**/**': '**',
     '**/**/**': '**'
-  }),
+  },
 
   // Digits
   CHAR_0: 48, /* 0 */

--- a/test/malicious.js
+++ b/test/malicious.js
@@ -30,4 +30,9 @@ describe('handling of potential regex exploits', () => {
       assert(!isMatch('A', `!(${repeat(500)}A)`, { maxLength: 499 }));
     }, /Input length: 504, exceeds maximum allowed length: 499/);
   });
+  it('should be able to accept Object instance properties', () => {
+    assert(isMatch('constructor', 'constructor'), 'valid match');
+    assert(isMatch('__proto__', '__proto__'), 'valid match');
+    assert(isMatch('toString', 'toString'), 'valid match');
+  });
 });


### PR DESCRIPTION
Picomatch will throw exceptions when the glob contains any Object instance property names.

Examples: `constructor`, `__proto__`, `toString`


Related to issue: https://github.com/streetsidesoftware/cspell/issues/7194