### PR TITLE
fix: fix incorrect replacement of Object properties

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -85,6 +85,11 @@ const POSIX_REGEX_SOURCE = {
   xdigit: 'A-Fa-f0-9'
 };
 
+const REPLACEMENTS = Object.create(null);
+REPLACEMENTS['***'] = '*';
+REPLACEMENTS['**/**'] = '**';
+REPLACEMENTS['**/**/**'] = '**';
+
 module.exports = {
   MAX_LENGTH: 1024 * 64,
   POSIX_REGEX_SOURCE,
@@ -98,11 +103,7 @@ module.exports = {
   REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
 
   // Replace globs with equivalent patterns to reduce parsing time.
-  REPLACEMENTS: {
-    '***': '*',
-    '**/**': '**',
-    '**/**/**': '**'
-  },
+  REPLACEMENTS: REPLACEMENTS,
 
   // Digits
   CHAR_0: 48, /* 0 */

--- a/test/api.picomatch.js
+++ b/test/api.picomatch.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const picomatch = require('..');
-const { isMatch } = picomatch;
+const { isMatch, makeRe } = picomatch;
 
 const assertTokens = (actual, expected) => {
   const keyValuePairs = actual.map(token => [token.type, token.value]);
@@ -376,6 +376,12 @@ describe('picomatch', () => {
         assert(!picomatch('(!(abc))', {}, true).state.negatedExtglob);
         assert(!picomatch('**!(abc)', {}, true).state.negatedExtglob);
       });
+    });
+  });
+
+  describe('makeRe', () => {
+    it('should work when supplying constructor as input', () => {
+      assert.strictEqual(makeRe('constructor').source, '^(?:^(?:constructor)$)$');
     });
   });
 });


### PR DESCRIPTION
When creating a RegExp via `makeRe` for one of the default properties of Object (`constructor` is one of them), the creation fails, because the replacement is applied. 

This PR fixes the issue by creating the replacement object without a prototype and adds a test to verify that it works correctly.