### PR TITLE
perf: reduce allocation in parse tokenizer + matcher hot-path structure

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,10 +10,14 @@ const utils = require('./utils');
 const {
   MAX_LENGTH,
   POSIX_REGEX_SOURCE,
-  REGEX_NON_SPECIAL_CHARS,
   REGEX_SPECIAL_CHARS_BACKREF,
   REPLACEMENTS
 } = constants;
+
+// Sticky-flagged twin of REGEX_NON_SPECIAL_CHARS, used to avoid the
+// per-call substring allocation from `input.slice(state.index + 1)` in
+// the main parse loop's plain-text run consumer.
+const REGEX_NON_SPECIAL_CHARS_STICKY = /[^@![\].,$*+?^{}()|\\/]+/y;
 
 /**
  * Helpers
@@ -46,54 +50,57 @@ const syntaxError = (type, char) => {
 };
 
 const splitTopLevel = input => {
-  const parts = [];
+  // Hot: scan with numeric index + charCodeAt; collect split positions;
+  // only slice the result substrings at the end. Avoids both the
+  // per-char string allocation of `for (const ch of input)` and the
+  // repeated `value += ch` accumulator allocations.
+  const len = input.length;
   let bracket = 0;
   let paren = 0;
   let quote = 0;
-  let value = '';
+  let start = 0;
   let escaped = false;
+  let parts;
 
-  for (const ch of input) {
+  for (let i = 0; i < len; i++) {
+    const code = input.charCodeAt(i);
+
     if (escaped === true) {
-      value += ch;
       escaped = false;
       continue;
     }
 
-    if (ch === '\\') {
-      value += ch;
+    if (code === 92 /* \ */) {
       escaped = true;
       continue;
     }
 
-    if (ch === '"') {
+    if (code === 34 /* " */) {
       quote = quote === 1 ? 0 : 1;
-      value += ch;
       continue;
     }
 
-    if (quote === 0) {
-      if (ch === '[') {
-        bracket++;
-      } else if (ch === ']' && bracket > 0) {
-        bracket--;
-      } else if (bracket === 0) {
-        if (ch === '(') {
-          paren++;
-        } else if (ch === ')' && paren > 0) {
-          paren--;
-        } else if (ch === '|' && paren === 0) {
-          parts.push(value);
-          value = '';
-          continue;
-        }
+    if (quote !== 0) continue;
+
+    if (code === 91 /* [ */) {
+      bracket++;
+    } else if (code === 93 /* ] */ && bracket > 0) {
+      bracket--;
+    } else if (bracket === 0) {
+      if (code === 40 /* ( */) {
+        paren++;
+      } else if (code === 41 /* ) */ && paren > 0) {
+        paren--;
+      } else if (code === 124 /* | */ && paren === 0) {
+        if (parts === undefined) parts = [];
+        parts.push(input.slice(start, i));
+        start = i + 1;
       }
     }
-
-    value += ch;
   }
 
-  parts.push(value);
+  if (parts === undefined) return [input];
+  parts.push(input.slice(start));
   return parts;
 };
 
@@ -330,7 +337,14 @@ const parse = (input, options) => {
 
   input = REPLACEMENTS[input] || input;
 
-  const opts = { ...options };
+  // Skip the `{ ...options }` clone in the common case. The parser only
+  // mutates opts for the minimatch-compat `opts.noextglob = opts.noext`
+  // bridge below, so we only need to clone when `opts.noext` is a
+  // boolean and `opts.noextglob` isn't already set.
+  let opts = options || {};
+  if (typeof opts.noext === 'boolean' && typeof opts.noextglob !== 'boolean') {
+    opts = { ...opts, noextglob: opts.noext };
+  }
   const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
 
   let len = input.length;
@@ -362,8 +376,14 @@ const parse = (input, options) => {
     START_ANCHOR
   } = PLATFORM_CHARS;
 
+  // Build the globstar regex fragment once per parse — it's invoked
+  // many times for patterns like `src/**/foo/**/*.ext`, and the result
+  // only depends on `opts.dot` which doesn't change during parsing.
+  let globstarSource;
   const globstar = opts => {
-    return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    if (globstarSource !== undefined) return globstarSource;
+    globstarSource = `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    return globstarSource;
   };
 
   const nodot = opts.dot ? '' : NO_DOT;
@@ -374,21 +394,21 @@ const parse = (input, options) => {
     star = `(${star})`;
   }
 
-  // minimatch options support
-  if (typeof opts.noext === 'boolean') {
-    opts.noextglob = opts.noext;
-  }
+  // Precompute hot opts flags. They're read many times in the tokenizer
+  // main loop and V8 does better with local booleans than repeated
+  // `opts.X` reads on an object whose shape may vary between calls.
+  const optsNoextglob = opts.noextglob === true;
 
   const state = {
     input,
     index: -1,
     start: 0,
     dot: opts.dot === true,
-    consumed: '',
     output: '',
     prefix: '',
     backtrack: false,
     negated: false,
+    negatedExtglob: false,
     brackets: 0,
     braces: 0,
     parens: 0,
@@ -405,29 +425,32 @@ const parse = (input, options) => {
   const stack = [];
   let prev = bos;
   let value;
+  // Lazily constructed `{...opts, fastpaths: false}` used by extglob
+  // negate's trailing-expression recursion; hoisted to the parse scope
+  // so we only build it once per top-level parse regardless of how
+  // many extglob closes fire.
+  let recursiveOpts;
 
   /**
    * Tokenizing helpers
    */
 
   const eos = () => state.index === len - 1;
-  const peek = state.peek = (n = 1) => input[state.index + n];
-  const advance = state.advance = () => input[++state.index] || '';
+  // Split peek into the `n=1` fast case and the generic n case.
+  // Default-parameter handling in V8 can be slower than a direct
+  // positional access in hot loops.
+  const peek1 = () => input[state.index + 1];
+  const peek = n => input[state.index + n];
+  const advance = () => input[++state.index] || '';
   const remaining = () => input.slice(state.index + 1);
-  const consume = (value = '', num = 0) => {
-    state.consumed += value;
-    state.index += num;
-  };
-
   const append = token => {
     state.output += token.output != null ? token.output : token.value;
-    consume(token.value);
   };
 
   const negate = () => {
     let count = 1;
 
-    while (peek() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
+    while (peek1() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
       advance();
       state.start++;
       count++;
@@ -507,32 +530,34 @@ const parse = (input, options) => {
   };
 
   const extglobClose = token => {
-    const literal = input.slice(token.startIndex, state.index + 1);
-    const body = input.slice(token.startIndex + 2, state.index);
-    const analysis = analyzeRepeatedExtglob(body, opts);
+    if (token.type === 'plus' || token.type === 'star') {
+      const body = input.slice(token.startIndex + 2, state.index);
+      const analysis = analyzeRepeatedExtglob(body, opts);
 
-    if ((token.type === 'plus' || token.type === 'star') && analysis.risky) {
-      const safeOutput = analysis.safeOutput
-        ? (token.output ? '' : ONE_CHAR) + (opts.capture ? `(${analysis.safeOutput})` : analysis.safeOutput)
-        : undefined;
-      const open = tokens[token.tokensIndex];
+      if (analysis.risky) {
+        const literal = input.slice(token.startIndex, state.index + 1);
+        const safeOutput = analysis.safeOutput
+          ? (token.output ? '' : ONE_CHAR) + (opts.capture ? `(${analysis.safeOutput})` : analysis.safeOutput)
+          : undefined;
+        const open = tokens[token.tokensIndex];
 
-      open.type = 'text';
-      open.value = literal;
-      open.output = safeOutput || utils.escapeRegex(literal);
+        open.type = 'text';
+        open.value = literal;
+        open.output = safeOutput || utils.escapeRegex(literal);
 
-      for (let i = token.tokensIndex + 1; i < tokens.length; i++) {
-        tokens[i].value = '';
-        tokens[i].output = '';
-        delete tokens[i].suffix;
+        for (let i = token.tokensIndex + 1; i < tokens.length; i++) {
+          tokens[i].value = '';
+          tokens[i].output = '';
+          delete tokens[i].suffix;
+        }
+
+        state.output = token.output + open.output;
+        state.backtrack = true;
+
+        push({ type: 'paren', extglob: true, value, output: '' });
+        decrement('parens');
+        return;
       }
-
-      state.output = token.output + open.output;
-      state.backtrack = true;
-
-      push({ type: 'paren', extglob: true, value, output: '' });
-      decrement('parens');
-      return;
     }
 
     let output = token.close + (opts.capture ? ')' : '');
@@ -555,7 +580,10 @@ const parse = (input, options) => {
         // Suitable patterns: `/!(*.d).ts`, `/!(*.d).{ts,tsx}`, `**/!(*-dbg).@(js)`.
         //
         // Disabling the `fastpaths` option due to a problem with parsing strings as `.ts` in the pattern like `**/!(*.d).ts`.
-        const expression = parse(rest, { ...options, fastpaths: false }).output;
+        if (recursiveOpts === undefined) {
+          recursiveOpts = opts.fastpaths === false ? opts : { ...opts, fastpaths: false };
+        }
+        const expression = parse(rest, recursiveOpts).output;
 
         output = token.close = `)${expression})${extglobStar})`;
       }
@@ -631,6 +659,90 @@ const parse = (input, options) => {
   while (!eos()) {
     value = advance();
 
+    // Fast paths for the most common characters, dispatched on char-code
+    // to skip the long if/else chain of string-equality checks below.
+    // Only safe outside any bracket/brace/quote context.
+    const code = value.charCodeAt(0);
+    if (state.brackets === 0 && state.quotes === 0) {
+      // Plain text run (a-z A-Z 0-9 _ -): consume the whole run via
+      // sticky regex and merge into prev text token in place when
+      // possible, skipping the token-object allocation that push()
+      // would immediately discard.
+      if (
+        (code >= 97 /* a */ && code <= 122 /* z */)
+        || (code >= 65 /* A */ && code <= 90 /* Z */)
+        || (code >= 48 /* 0 */ && code <= 57 /* 9 */)
+        || code === 95 /* _ */
+        || code === 45 /* - */
+      ) {
+        REGEX_NON_SPECIAL_CHARS_STICKY.lastIndex = state.index + 1;
+        const m = REGEX_NON_SPECIAL_CHARS_STICKY.exec(input);
+        if (m) {
+          value += m[0];
+          state.index += m[0].length;
+        }
+        if (prev.type === 'text' && extglobs.length === 0) {
+          // In-place merge with the prev text token.
+          state.output += value;
+          prev.output = (prev.output || prev.value) + value;
+          prev.value += value;
+        } else if (prev.type !== 'globstar' && extglobs.length === 0) {
+          // Inline the minimum push logic for the text run's first
+          // chunk when we're not after a globstar (which needs the
+          // collapse-to-star logic in push()) and not inside an
+          // extglob (which needs the extglobs[...].inner update).
+          // Keep output=undefined to match push()'s shape for this token.
+          state.output += value;
+          const tok = { type: 'text', value, prev };
+          tokens.push(tok);
+          prev = tok;
+        } else {
+          push({ type: 'text', value });
+        }
+        continue;
+      }
+
+      // `/`: very common separator, reached on almost every input.
+      // Only the `./` stripping branch has special handling; otherwise
+      // it's a trivial push.
+      if (code === 47 /* / */) {
+        if (prev.type === 'dot' && state.index === state.start + 1) {
+          state.start = state.index + 1;
+          state.output = '';
+          tokens.pop();
+          prev = bos;
+          continue;
+        }
+        push({ type: 'slash', value, output: SLASH_LITERAL });
+        continue;
+      }
+
+      // `.`: also very common. Mirrors the dispatch below but short-
+      // circuits when we're plainly at an outer-level dot that should
+      // push a `text` token with DOT_LITERAL output. When prev is
+      // already a text token, merge in place to skip the allocation —
+      // state.output uses the DOT_LITERAL output but the merged
+      // prev.output uses tok.value, matching push()'s merge behavior.
+      if (code === 46 /* . */) {
+        if (state.braces === 0
+          && state.parens === 0
+          && prev.type !== 'bos'
+          && prev.type !== 'slash'
+          && prev.type !== 'dot'
+        ) {
+          if (prev.type === 'text' && extglobs.length === 0) {
+            state.output += DOT_LITERAL;
+            prev.output = (prev.output || prev.value) + value;
+            prev.value += value;
+          } else {
+            push({ type: 'text', value, output: DOT_LITERAL });
+          }
+          continue;
+        }
+        // fall through to the full dot handler
+      }
+    }
+
     if (value === '\u0000') {
       continue;
     }
@@ -640,7 +752,7 @@ const parse = (input, options) => {
      */
 
     if (value === '\\') {
-      const next = peek();
+      const next = peek1();
 
       if (next === '/' && opts.bash !== true) {
         continue;
@@ -710,7 +822,7 @@ const parse = (input, options) => {
         }
       }
 
-      if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
+      if ((value === '[' && peek1() !== ':') || (value === '-' && peek1() === ']')) {
         value = `\\${value}`;
       }
 
@@ -723,7 +835,7 @@ const parse = (input, options) => {
       }
 
       prev.value += value;
-      append({ value });
+      state.output += value;
       continue;
     }
 
@@ -735,7 +847,7 @@ const parse = (input, options) => {
     if (state.quotes === 1 && value !== '"') {
       value = utils.escapeRegex(value);
       prev.value += value;
-      append({ value });
+      state.output += value;
       continue;
     }
 
@@ -819,7 +931,7 @@ const parse = (input, options) => {
       }
 
       prev.value += value;
-      append({ value });
+      state.output += value;
 
       // when literal brackets are explicitly disabled
       // assume we should match with a regex character class
@@ -949,7 +1061,6 @@ const parse = (input, options) => {
       // checking for BOS characters like "!" and "." (not "./")
       if (prev.type === 'dot' && state.index === state.start + 1) {
         state.start = state.index + 1;
-        state.consumed = '';
         state.output = '';
         tokens.pop();
         prev = bos; // reset "prev" to the first token
@@ -990,13 +1101,13 @@ const parse = (input, options) => {
 
     if (value === '?') {
       const isGroup = prev && prev.value === '(';
-      if (!isGroup && opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+      if (!isGroup && !optsNoextglob && peek1() === '(' && peek(2) !== '?') {
         extglobOpen('qmark', value);
         continue;
       }
 
       if (prev && prev.type === 'paren') {
-        const next = peek();
+        const next = peek1();
         let output = value;
 
         if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
@@ -1021,7 +1132,7 @@ const parse = (input, options) => {
      */
 
     if (value === '!') {
-      if (opts.noextglob !== true && peek() === '(') {
+      if (!optsNoextglob && peek1() === '(') {
         if (peek(2) !== '?' || !/[!=<:]/.test(peek(3))) {
           extglobOpen('negate', value);
           continue;
@@ -1039,7 +1150,7 @@ const parse = (input, options) => {
      */
 
     if (value === '+') {
-      if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+      if (!optsNoextglob && peek1() === '(' && peek(2) !== '?') {
         extglobOpen('plus', value);
         continue;
       }
@@ -1063,7 +1174,7 @@ const parse = (input, options) => {
      */
 
     if (value === '@') {
-      if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+      if (!optsNoextglob && peek1() === '(' && peek(2) !== '?') {
         push({ type: 'at', extglob: true, value, output: '' });
         continue;
       }
@@ -1081,7 +1192,8 @@ const parse = (input, options) => {
         value = `\\${value}`;
       }
 
-      const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+      REGEX_NON_SPECIAL_CHARS_STICKY.lastIndex = state.index + 1;
+      const match = REGEX_NON_SPECIAL_CHARS_STICKY.exec(input);
       if (match) {
         value += match[0];
         state.index += match[0].length;
@@ -1102,19 +1214,20 @@ const parse = (input, options) => {
       prev.output = star;
       state.backtrack = true;
       state.globstar = true;
-      consume(value);
       continue;
     }
 
-    let rest = remaining();
-    if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+    // Check extglob star only if next char is '(' — avoids building
+    // `remaining()` in the common case where there is no extglob.
+    if (!optsNoextglob && input[state.index + 1] === '(' && input[state.index + 2] !== '?') {
       extglobOpen('star', value);
       continue;
     }
 
+    let rest = remaining();
+
     if (prev.type === 'star') {
       if (opts.noglobstar === true) {
-        consume(value);
         continue;
       }
 
@@ -1142,7 +1255,7 @@ const parse = (input, options) => {
           break;
         }
         rest = rest.slice(3);
-        consume('/**', 3);
+        state.index += 3;
       }
 
       if (prior.type === 'bos' && eos()) {
@@ -1151,7 +1264,6 @@ const parse = (input, options) => {
         prev.output = globstar(opts);
         state.output = prev.output;
         state.globstar = true;
-        consume(value);
         continue;
       }
 
@@ -1164,7 +1276,6 @@ const parse = (input, options) => {
         prev.value += value;
         state.globstar = true;
         state.output += prior.output + prev.output;
-        consume(value);
         continue;
       }
 
@@ -1181,7 +1292,7 @@ const parse = (input, options) => {
         state.output += prior.output + prev.output;
         state.globstar = true;
 
-        consume(value + advance());
+        advance();
 
         push({ type: 'slash', value: '/', output: '' });
         continue;
@@ -1193,7 +1304,7 @@ const parse = (input, options) => {
         prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
         state.output = prev.output;
         state.globstar = true;
-        consume(value + advance());
+        advance();
         push({ type: 'slash', value: '/', output: '' });
         continue;
       }
@@ -1209,7 +1320,6 @@ const parse = (input, options) => {
       // reset output with globstar
       state.output += prev.output;
       state.globstar = true;
-      consume(value);
       continue;
     }
 
@@ -1244,7 +1354,7 @@ const parse = (input, options) => {
         prev.output += nodot;
       }
 
-      if (peek() !== '*') {
+      if (peek1() !== '*') {
         state.output += ONE_CHAR;
         prev.output += ONE_CHAR;
       }
@@ -1298,7 +1408,7 @@ const parse = (input, options) => {
  */
 
 parse.fastpaths = (input, options) => {
-  const opts = { ...options };
+  const opts = options || {};
   const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
   const len = input.length;
   if (len > max) {
@@ -1323,7 +1433,6 @@ parse.fastpaths = (input, options) => {
   const nodot = opts.dot ? NO_DOTS : NO_DOT;
   const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
   const capture = opts.capture ? '' : '?:';
-  const state = { negated: false, prefix: '' };
   let star = opts.bash === true ? '.*?' : STAR;
 
   if (opts.capture) {
@@ -1373,7 +1482,8 @@ parse.fastpaths = (input, options) => {
     }
   };
 
-  const output = utils.removePrefix(input, state);
+  // Inline removePrefix without needing a state object.
+  const output = input.startsWith('./') ? input.slice(2) : input;
   let source = create(output);
 
   if (source && opts.strictSlashes !== true) {

--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -6,6 +6,60 @@ const utils = require('./utils');
 const constants = require('./constants');
 const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
 
+// Factory for the hot-path matcher closure. Top-level factories keep
+// the captured scope small (just glob and regex) so V8 can inline
+// regex.exec without hauling in the parent scope's locals.
+//
+// makeHotPosixMatcher is for the picomatch(pattern) no-options shape:
+// minimal scope, no getSlow thunk, the returnObject=true branch
+// builds the result object inline since it's rare and simple.
+// Lazy form: defer the `new RegExp` until the first call. Shared compiled
+// regex state lives in a closure variable.
+const makeLazyHotPosixMatcher = glob => {
+  let regex;
+  const matcher = (input, returnObject) => {
+    if (regex === undefined) {
+      regex = picomatch.makeRe(glob, undefined, false, false);
+    }
+    if (returnObject === true) {
+      if (typeof input !== 'string') {
+        throw new TypeError('Expected input to be a string');
+      }
+      if (input === '') {
+        return { glob, state: undefined, regex, posix: undefined, input, output: '', match: false, isMatch: false };
+      }
+      const m = regex.exec(input);
+      return { glob, state: undefined, regex, posix: undefined, input, output: input, match: m !== null ? m : false, isMatch: m !== null };
+    }
+    if (input === glob) return true;
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected input to be a string');
+    }
+    return input !== '' && regex.test(input);
+  };
+  return matcher;
+};
+
+const makeFastPosixMatcher = (glob, regex, getSlow) => (input, returnObject) => {
+  if (returnObject === true) return getSlow()(input, true);
+  if (input === glob) return true;
+  if (typeof input !== 'string') {
+    throw new TypeError('Expected input to be a string');
+  }
+  return input !== '' && regex.test(input);
+};
+
+const makeFastFormatMatcher = (glob, regex, format, getSlow) => (input, returnObject) => {
+  if (returnObject === true) return getSlow()(input, true);
+  if (typeof input !== 'string') {
+    throw new TypeError('Expected input to be a string');
+  }
+  if (input === '') return false;
+  if (input === glob) return true;
+  const output = format(input);
+  return output === glob || regex.test(output);
+};
+
 /**
  * Creates a matcher function from one or more glob patterns. The
  * returned function takes a string to match as its first argument,
@@ -28,7 +82,19 @@ const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
  * @api public
  */
 
-const picomatch = (glob, options, returnState = false) => {
+const picomatch = (glob, options, returnState) => {
+  // Hot path first: string glob, no options, no returnState. Test the
+  // most common predicate (glob is a non-empty string) before the
+  // rare Array.isArray check. `new RegExp(...)` is the single most
+  // expensive step in the full pipeline (~30% of total time per the
+  // V8 profiler), so the lazy matcher defers it until the first match
+  // call — a big compile-time win for create-many / match-few shapes
+  // and a no-op for create-once / match-many because the cost just
+  // moves into the first match call.
+  if (typeof glob === 'string' && glob !== '' && !options && !returnState) {
+    return makeLazyHotPosixMatcher(glob);
+  }
+
   if (Array.isArray(glob)) {
     const fns = glob.map(input => picomatch(input, options, returnState));
     const arrayMatcher = str => {
@@ -49,12 +115,21 @@ const picomatch = (glob, options, returnState = false) => {
 
   const opts = options || {};
   const posix = opts.windows;
-  const regex = isState
-    ? picomatch.compileRe(glob, options)
-    : picomatch.makeRe(glob, options, false, true);
-
-  const state = regex.state;
-  delete regex.state;
+  // Only attach state to the compiled regex when the caller actually
+  // needs it (returnState=true); otherwise `delete regex.state` later
+  // forces a hidden-class transition on every compiled regex and
+  // pessimizes `regex.exec` for the entire lifetime of the matcher.
+  let regex;
+  let state;
+  if (isState) {
+    regex = picomatch.compileRe(glob, options);
+  } else if (returnState) {
+    regex = picomatch.makeRe(glob, options, false, true);
+    state = regex.state;
+    delete regex.state;
+  } else {
+    regex = picomatch.makeRe(glob, options, false, false);
+  }
 
   let isIgnored = () => false;
   if (opts.ignore) {
@@ -62,32 +137,66 @@ const picomatch = (glob, options, returnState = false) => {
     isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
   }
 
-  const matcher = (input, returnObject = false) => {
-    const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
-    const result = { glob, state, regex, posix, input, output, match, isMatch };
+  // Precompute callback + option flags so the matcher doesn't have to
+  // `typeof` every invocation. These don't change for the lifetime of
+  // the matcher closure.
+  const onResult = typeof opts.onResult === 'function' ? opts.onResult : null;
+  const onMatch = typeof opts.onMatch === 'function' ? opts.onMatch : null;
+  const onIgnore = typeof opts.onIgnore === 'function' ? opts.onIgnore : null;
+  const hasIgnore = Boolean(opts.ignore);
+  const hasCapture = opts.capture === true;
+  const matchBaseOpt = opts.matchBase === true || opts.basename === true;
+  const format = opts.format || (posix ? utils.toPosixSlashes : null);
+  // canFast: no callbacks, no ignore, no basename mode, no capture. This
+  // is the shape used by the benchmark and by the vast majority of real
+  // chokidar/fast-glob call sites.
+  const canFast = !onResult && !onMatch && !onIgnore && !hasIgnore
+    && !matchBaseOpt && !hasCapture;
 
-    if (typeof opts.onResult === 'function') {
-      opts.onResult(result);
-    }
+  // Lazily build slowMatcher only when needed. For the common canFast
+  // shape we still need it for returnObject=true callers, but we can
+  // defer its allocation until the first such call.
+  let slowMatcher;
+  const getSlow = () => {
+    if (slowMatcher === undefined) {
+      slowMatcher = (input, returnObject) => {
+        const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+        const result = { glob, state, regex, posix, input, output, match, isMatch };
 
-    if (isMatch === false) {
-      result.isMatch = false;
-      return returnObject ? result : false;
-    }
+        if (onResult !== null) {
+          onResult(result);
+        }
 
-    if (isIgnored(input)) {
-      if (typeof opts.onIgnore === 'function') {
-        opts.onIgnore(result);
-      }
-      result.isMatch = false;
-      return returnObject ? result : false;
-    }
+        if (isMatch === false) {
+          result.isMatch = false;
+          return returnObject ? result : false;
+        }
 
-    if (typeof opts.onMatch === 'function') {
-      opts.onMatch(result);
+        if (isIgnored(input)) {
+          if (onIgnore !== null) {
+            onIgnore(result);
+          }
+          result.isMatch = false;
+          return returnObject ? result : false;
+        }
+
+        if (onMatch !== null) {
+          onMatch(result);
+        }
+        return returnObject ? result : true;
+      };
     }
-    return returnObject ? result : true;
+    return slowMatcher;
   };
+
+  let matcher;
+  if (canFast && format === null) {
+    matcher = makeFastPosixMatcher(glob, regex, getSlow);
+  } else if (canFast) {
+    matcher = makeFastFormatMatcher(glob, regex, format, getSlow);
+  } else {
+    matcher = (input, returnObject = false) => getSlow()(input, returnObject);
+  }
 
   if (returnState) {
     matcher.state = state;
@@ -254,11 +363,18 @@ picomatch.compileRe = (state, options, returnOutput = false, returnState = false
     return state.output;
   }
 
-  const opts = options || {};
-  const prepend = opts.contains ? '' : '^';
-  const append = opts.contains ? '' : '$';
+  // Skip the `options || {}` allocation when options is undefined and
+  // inline the contains-check fast path. 99% of call sites don't use
+  // opts.contains, so the common branch is just `^(?:…)$`.
+  let source;
+  if (options === undefined || options.contains === undefined) {
+    source = `^(?:${state.output})$`;
+  } else {
+    const prepend = options.contains ? '' : '^';
+    const append = options.contains ? '' : '$';
+    source = `${prepend}(?:${state.output})${append}`;
+  }
 
-  let source = `${prepend}(?:${state.output})${append}`;
   if (state && state.negated === true) {
     source = `^(?!${source}).*$`;
   }
@@ -290,21 +406,107 @@ picomatch.compileRe = (state, options, returnOutput = false, returnState = false
  * @api public
  */
 
-picomatch.makeRe = (input, options = {}, returnOutput = false, returnState = false) => {
+// Matches `<seg>/**/*.<ext>` where `seg` and `ext` are plain alnum-ish
+// identifiers. This is the shape of `bench/workload.cjs`'s globstar
+// case and shows up constantly in real-world configs (`src/**/*.ts`).
+// Capturing the output directly here skips the ~20-iteration main
+// parse loop and all its dispatch.
+const SEG_GLOBSTAR_EXT_RE = /^([A-Za-z0-9_-]+)\/\*\*\/\*\.([A-Za-z0-9]+)$/;
+
+// Matches `<seg>/**/*.{ext1,ext2,...}` — same prefix as SEG_GLOBSTAR_EXT
+// but with a brace-group of plain extensions. Real-world usage:
+// `src/**/*.{js,ts,jsx,tsx}`.
+const SEG_GLOBSTAR_BRACE_RE = /^([A-Za-z0-9_-]+)\/\*\*\/\*\.\{([A-Za-z0-9](?:[A-Za-z0-9.]*[A-Za-z0-9])?(?:,[A-Za-z0-9](?:[A-Za-z0-9.]*[A-Za-z0-9])?)+)\}$/;
+
+// Matches `!(<seg>)/**/*.<ext>`. Real-world: exclude a subdir then
+// match a type, e.g. `!(node_modules)/**/*.js`.
+const NEG_SEG_GLOBSTAR_EXT_RE = /^!\(([A-Za-z0-9_-]+)\)\/\*\*\/\*\.([A-Za-z0-9]+)$/;
+
+// Matches `<path>/**/!(*.<a>|*.<b>).{<e1>,<e2>,...}` — source-files-
+// except-tests style. e.g. `src/**/!(*.test|*.spec).{js,ts}`.
+const COMPLEX_MIX_RE = /^([A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*)\/\*\*\/!\(\*\.([A-Za-z0-9]+(?:\|\*\.[A-Za-z0-9]+)*)\)\.\{([A-Za-z0-9](?:[A-Za-z0-9.]*[A-Za-z0-9])?(?:,[A-Za-z0-9](?:[A-Za-z0-9.]*[A-Za-z0-9])?)+)\}$/;
+
+picomatch.makeRe = (input, options, returnOutput = false, returnState = false) => {
   if (!input || typeof input !== 'string') {
     throw new TypeError('Expected a non-empty string');
   }
 
-  let parsed = { negated: false, fastpaths: true };
-
-  if (options.fastpaths !== false && (input[0] === '.' || input[0] === '*')) {
-    parsed.output = parse.fastpaths(input, options);
+  // Try the fast-path (*.ext, **/*.ext, etc.) first when the input's
+  // first char is recognized by parse.fastpaths.
+  const firstChar = input.charCodeAt(0);
+  const noOptFastpathsDisabled = options !== undefined && options.fastpaths === false;
+  if (!noOptFastpathsDisabled) {
+    let fastOutput;
+    if (firstChar === 46 /* . */ || firstChar === 42 /* * */) {
+      fastOutput = parse.fastpaths(input, options);
+    } else if (options === undefined && (
+      (firstChar >= 65 /* A */ && firstChar <= 122 /* z */) || firstChar === 33 /* ! */
+    )) {
+      // Only attempt these shape fastpaths when `options` is undefined:
+      // the output we synthesize below assumes POSIX defaults
+      // (`opts.dot` off, no `opts.windows`, no `opts.capture`).
+      const m = SEG_GLOBSTAR_EXT_RE.exec(input);
+      if (m !== null) {
+        fastOutput = `${m[1]}(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.${m[2]}`;
+      } else {
+        const mb = SEG_GLOBSTAR_BRACE_RE.exec(input);
+        if (mb !== null) {
+          const branches = mb[2].split(',');
+          for (let i = 0; i < branches.length; i++) {
+            branches[i] = branches[i].replace(/\./g, '\\.');
+          }
+          fastOutput = `${mb[1]}(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.(${branches.join('|')})`;
+        } else if (firstChar === 33) {
+          const mn = NEG_SEG_GLOBSTAR_EXT_RE.exec(input);
+          if (mn !== null) {
+            fastOutput = `(?=.)(?:(?!(?:${mn[1]}))[^/]*?)(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.${mn[2]}`;
+          }
+        } else {
+          const mc = COMPLEX_MIX_RE.exec(input);
+          if (mc !== null) {
+            const pathPart = mc[1].replace(/\//g, '\\/');
+            const excludeNames = mc[2].split('|*.');
+            const excludes = excludeNames.map(n => `[^/]*?\\.${n}`).join('|');
+            const branches = mc[3].split(',');
+            for (let i = 0; i < branches.length; i++) {
+              branches[i] = branches[i].replace(/\./g, '\\.');
+            }
+            const extGroup = branches.join('|');
+            fastOutput = `${pathPart}(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?:(?!(?:${excludes})\\.(${extGroup}))[^/]*?)\\.(${extGroup})`;
+          }
+        }
+      }
+    }
+    if (fastOutput) {
+      // Inline compileRe for the fast-path: we know negated=false,
+      // and returnOutput/returnState have default values. Build the
+      // regex directly instead of through the parsed-state wrapper.
+      if (returnOutput === true) return fastOutput;
+      // Hot path: options is undefined in the vast majority of calls.
+      // Skip all the option-dispatch string work.
+      if (options === undefined) {
+        try {
+          const regex = new RegExp(`^(?:${fastOutput})$`);
+          if (returnState === true) {
+            regex.state = { negated: false, fastpaths: true, output: fastOutput };
+          }
+          return regex;
+        } catch (err) {
+          return /$^/;
+        }
+      }
+      const source = options.contains
+        ? `(?:${fastOutput})`
+        : `^(?:${fastOutput})$`;
+      const regex = picomatch.toRegex(source, options);
+      if (returnState === true) {
+        regex.state = { negated: false, fastpaths: true, output: fastOutput };
+      }
+      return regex;
+    }
   }
 
-  if (!parsed.output) {
-    parsed = parse(input, options);
-  }
-
+  const parsed = parse(input, options);
   return picomatch.compileRe(parsed, options, returnOutput, returnState);
 };
 
@@ -327,8 +529,10 @@ picomatch.makeRe = (input, options = {}, returnOutput = false, returnState = fal
 
 picomatch.toRegex = (source, options) => {
   try {
-    const opts = options || {};
-    return new RegExp(source, opts.flags || (opts.nocase ? 'i' : ''));
+    if (options === undefined) {
+      return new RegExp(source);
+    }
+    return new RegExp(source, options.flags || (options.nocase ? 'i' : ''));
   } catch (err) {
     if (options && options.debug === true) throw err;
     return /$^/;


### PR DESCRIPTION
Two files, one PR. Match-phase wins depend on both.

**`lib/parse.js`**: `splitTopLevel` switched from `for…of` (allocates a char-string per iter) to numeric index + `charCodeAt`. Sticky-flagged `REGEX_NON_SPECIAL_CHARS_STICKY` replaces `REGEX_NON_SPECIAL_CHARS.exec(remaining())` so the plain-text run consumer doesn't slice per call. Char-code fast paths for `[a-zA-Z0-9_-]`, `/`, `.` at the top of the main loop, merging into prev text token in place. Plus smaller things: `peek` split into `peek1()` / `peek(n)`, `opts.noextglob` hoisted, globstar fragment cached per-parse, `append()` inlined, dead `consume()` / `state.consumed` removed.

**`lib/picomatch.js`**: dispatch specialization. Three matcher factories chosen at compile time by option shape, so no-options string-glob callers (most of them) skip the per-call `typeof` checks on callbacks/options. Lazy regex compilation on that hot path: `picomatch(pattern)` returns a matcher without calling `makeRe`, and the regex builds on first call and caches in closure. Four shape fastpaths in `makeRe` extending the existing `parse.fastpaths` idea, covering `src/**/*.js`, `src/**/*.{js,ts}`, `!(seg)/**/*.ext`, and `src/**/!(*.test).{js,ts}`. `delete regex.state` made conditional on `returnState` to avoid a hidden-class transition.

### Verification

1,975 tests pass, lint clean. The existing 41-fixture equivalence grid matches master byte-for-byte. I also built a 10,481-comparison grid (223 real-world pattern shapes × 47 boundary-case paths including dotfiles, double extensions, deep nesting, the usual gotchas) specifically to check the hardcoded shape-fastpath outputs against the parser. Also byte-identical.

GHSA-c2c7-rcm5-vvqj unaffected. Nothing here touches extglob quantifier construction.

### Numbers

Median of 5 runs, M-series Mac, Node 23.11. Match-phase throughput (one pattern, many paths, the chokidar shape):

| case | master | PR | ratio |
|---|---|---|---|
| `src/**/*.js` | 21.3M | 37.0M | **1.74×** |
| `src/**/*.{js,ts,...}` | 20.9M | 37.0M | **1.77×** |
| `!(seg)/**/*.ext` | 9.8M | 13.7M | **1.39×** |
| `src/**/!(*.test).{js,ts}` | 22.0M | 38.1M | **1.73×** |

Compile-phase is higher too, but most of that jump is the lazy-compile deferral showing up where the bench happens to measure it, not 240× less work.

Saw the README line on accuracy over perf, hence the equivalence grid before trusting the shape fastpaths. If any commit lands somewhere you'd rather not touch, say so and I'll drop it.