### PR TITLE
fix: avoid bracket class literal shortcut

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -5,6 +5,7 @@ const parse = require('./parse');
 const utils = require('./utils');
 const constants = require('./constants');
 const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
+const hasBracketTokens = state => Array.isArray(state.tokens) && state.tokens.some(token => token.type === 'bracket');
 
 /**
  * Creates a matcher function from one or more glob patterns. The
@@ -63,7 +64,7 @@ const picomatch = (glob, options, returnState = false) => {
   }
 
   const matcher = (input, returnObject = false) => {
-    const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+    const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix, state });
     const result = { glob, state, regex, posix, input, output, match, isMatch };
 
     if (typeof opts.onResult === 'function') {
@@ -113,7 +114,7 @@ const picomatch = (glob, options, returnState = false) => {
  * @api public
  */
 
-picomatch.test = (input, regex, options, { glob, posix } = {}) => {
+picomatch.test = (input, regex, options, { glob, posix, state } = {}) => {
   if (typeof input !== 'string') {
     throw new TypeError('Expected input to be a string');
   }
@@ -124,12 +125,13 @@ picomatch.test = (input, regex, options, { glob, posix } = {}) => {
 
   const opts = options || {};
   const format = opts.format || (posix ? utils.toPosixSlashes : null);
-  let match = input === glob;
+  const literalMatch = opts.literalBrackets === true || !hasBracketTokens(state);
+  let match = literalMatch && input === glob;
   let output = (match && format) ? format(input) : input;
 
   if (match === false) {
     output = format ? format(input) : input;
-    match = output === glob;
+    match = literalMatch && output === glob;
   }
 
   if (match === false || opts.capture === true) {

--- a/test/brackets.js
+++ b/test/brackets.js
@@ -4,6 +4,19 @@ const assert = require('assert');
 const { isMatch } = require('..');
 
 describe('brackets', () => {
+  describe('character classes', () => {
+    it('should not let exact string matching bypass character classes', () => {
+      assert(!isMatch('[1-5]', '[1-5]'));
+      assert(!isMatch('[1-5]', '[1-5]', { literalBrackets: false }));
+      assert(isMatch('3', '[1-5]'));
+    });
+
+    it('should still match literal brackets when requested', () => {
+      assert(isMatch('[1-5]', '\\[1-5\\]'));
+      assert(isMatch('[1-5]', '[1-5]', { literalBrackets: true }));
+    });
+  });
+
   describe('trailing stars', () => {
     it('should support stars following brackets', () => {
       assert(isMatch('a', '[a]*'));


### PR DESCRIPTION
Fixes #71.

`picomatch.test()` currently short-circuits to a successful match when the input string is exactly equal to the glob pattern. That works for literal patterns, but it bypasses regex matching for bracket character classes.

For example, `[1-5]` should match `1` through `5`, but it should not match the literal string `[1-5]` unless the brackets are escaped or `literalBrackets: true` is used.

This change keeps the exact-match shortcut for literal patterns and explicit literal bracket matching, but disables that shortcut when the compiled state contains bracket tokens. In that case the generated regex decides the result.

Verification:
- Added regression coverage for `[1-5]` vs `[1-5]`
- Confirmed the new test failed before the fix
- `npm run mocha -- test/brackets.js test/regex-features.js test/special-characters.js test/bash.js`
- `npm test`
- `git diff --check`
