### PR TITLE
fix: preserve globstar in non-final extglob alternatives

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -463,7 +463,7 @@ const parse = (input, options) => {
   const push = tok => {
     if (prev.type === 'globstar') {
       const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
-      const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
+      const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.value === '|' || tok.type === 'paren'));
 
       if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
         state.output = state.output.slice(0, -prev.output.length);

--- a/test/extglobs.js
+++ b/test/extglobs.js
@@ -769,5 +769,23 @@ describe('extglobs', () => {
     assert.deepStrictEqual(match(['a123c', 'abbbc'], 'a[\\D]+c'), ['abbbc'], 'Should match non-numbers');
     assert.deepStrictEqual(match(['foo', ' foo '], '(f|o)+\\b'), ['foo'], 'Should match word boundaries');
   });
+
+  it('should keep globstar semantics for non-final extglob alternatives (issue #154)', () => {
+    const opts = { dot: true };
+
+    // The result of a negation extglob must not depend on the order of the
+    // alternatives: every alternative's `**` must match deep paths, not only
+    // the last one.
+    assert(!isMatch('a/x/y', '!(a/**|b/**)**', opts));
+    assert(!isMatch('a/x/y', '!(b/**|a/**)**', opts));
+
+    assert(!isMatch('amplify/backend/fn/jest.config.ts', '!(amplify/**|data/**)**', opts));
+    assert(!isMatch('amplify/backend/fn/jest.config.ts', '!(data/**|amplify/**)**', opts));
+
+    // The last alternative still excludes deep paths as before...
+    assert(!isMatch('b/x/y', '!(a/**|b/**)**', opts));
+    // ...and unrelated paths are still matched (the negation does not over-exclude).
+    assert(isMatch('c/x/y', '!(a/**|b/**)**', opts));
+  });
 });
 


### PR DESCRIPTION
Fixes #154.

### Problem

In a negation extglob like `!(a/**|b/**)`, the result depends on the **order** of the alternatives:

```js
const pm = require('picomatch');
const opts = { dot: true };

pm('!(a/**|b/**)**', opts)('a/x/y'); // => true  (wrong — a/** should exclude it)
pm('!(b/**|a/**)**', opts)('a/x/y'); // => false (correct)
```

Only the **last** alternative's `**` compiles to a real globstar. Every non-final alternative's `**` is silently downgraded to a single path segment (`[^/]*?`), so it can't match deep paths inside the lookahead — and the negation fails to exclude them.

### Cause

The globstar-downgrade guard in `push` (`lib/parse.js`) keeps a `**` as a globstar when the following token is a pipe:

```js
const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
```

But the `|` token is pushed as `{ type: 'text', value: '|' }` (see the `Pipes` branch), never `type: 'pipe'`. So `tok.type === 'pipe'` is effectively dead code and the preceding globstar gets downgraded. The last alternative survives only because it is followed by `)` (`type: 'paren'`, which *is* guarded) — hence the order-dependence.

### Fix

Also treat a token whose value is `|` as an extglob boundary:

```js
const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.value === '|' || tok.type === 'paren'));
```

This is surgical — it only affects `**` immediately followed by `|` inside an extglob.

### Tests

Added a regression test in `test/extglobs.js` asserting the negation result is independent of alternative order, that the last alternative still excludes deep paths, and that unrelated paths are still matched (no over-exclusion).

Full suite: **1976 passing**, lint clean. Verified the new test fails on `master` and passes with the fix.
