### PR TITLE
fix: forward `windows` option to basename in matchBase

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -157,9 +157,9 @@ picomatch.test = (input, regex, options, { glob, posix } = {}) => {
  * @api public
  */
 
-picomatch.matchBase = (input, glob, options) => {
+picomatch.matchBase = (input, glob, options, posix = options && options.windows) => {
   const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
-  return regex.test(utils.basename(input));
+  return regex.test(utils.basename(input, { windows: posix }));
 };
 
 /**

--- a/test/options.js
+++ b/test/options.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const match = require('./support/match');
-const { isMatch } = require('..');
+const { isMatch, matchBase } = require('..');
 
 describe('options', () => {
   describe('options.matchBase', () => {
@@ -13,6 +13,19 @@ describe('options', () => {
       assert.deepStrictEqual(match(['a/b/c/d.md'], '*.md', { matchBase: true, windows: true }), ['a/b/c/d.md']);
       assert.deepStrictEqual(match(['a/b/c/foo.md'], '*.md', { matchBase: true, windows: true }), ['a/b/c/foo.md']);
       assert.deepStrictEqual(match(['x/y/acb', 'acb/', 'acb/d/e', 'x/y/acb/d'], 'a?b', { matchBase: true, windows: true }), ['x/y/acb', 'acb/']);
+    });
+
+    it('should match the basename of backslash-separated paths when `options.windows` is true', () => {
+      assert(isMatch('foo\\bar.js', '*.js', { matchBase: true, windows: true }));
+      assert(isMatch('a\\b\\c\\d.md', '*.md', { matchBase: true, windows: true }));
+      assert(isMatch('a\\b\\c\\foo.md', '*.md', { matchBase: true, windows: true }));
+      assert(isMatch('x\\y\\acb', 'a?b', { matchBase: true, windows: true }));
+      assert(!isMatch('a\\b\\c\\d.md', '*.js', { matchBase: true, windows: true }));
+    });
+
+    it('should pass the `windows` option through `matchBase`', () => {
+      assert(matchBase('foo\\bar.js', '*.js', { windows: true }));
+      assert(matchBase('a\\b\\c\\d.md', '*.md', { windows: true }));
     });
 
     it('should work with negation patterns', () => {


### PR DESCRIPTION
## What

`picomatch.matchBase` no longer honors the `windows` option, so backslash-separated paths are not split into segments when matching a basename pattern with `{ matchBase: true, windows: true }`.

```js
const picomatch = require('picomatch');

picomatch.isMatch('a\\b\\c\\foo.md', '*.md', { matchBase: true, windows: true });
//=> false  (expected: true)

picomatch.matchBase('foo\\bar.js', '*.js', { windows: true });
//=> false  (expected: true)
```

Forward-slash paths work as expected; only backslash separators are affected.

## Why

When `windows: true`, the parser builds a regex whose path-segment class excludes both separators (`[^\\/]`), so a multi-segment backslash path like `a\b\c\foo.md` can't match a single-segment pattern like `*.md` directly. Matching then falls back to `picomatch.matchBase`, which is supposed to test the *basename* of the input.

`picomatch.test` still passes the `posix`/windows flag to `matchBase`:

```js
match = picomatch.matchBase(input, regex, options, posix);
```

but in #64 (commit `2f25761`, "Remove automatic windows detection") `matchBase` was changed from Node's `path.basename` to the internal `utils.basename`, and in the process:

- the trailing `posix` parameter was dropped from the signature, and
- `utils.basename(input)` was called **without** the `{ windows }` flag.

`utils.basename` already supports `{ windows: true }` (and is covered by tests in `test/regex-features.js`), so without the flag it only ever splits on `/`. For a backslash path it returns the whole string, which then fails the regex.

## Fix

Restore the `posix` parameter (defaulting to `options.windows`, mirroring how `picomatch.test` derives it) and forward it to `utils.basename`:

```js
picomatch.matchBase = (input, glob, options, posix = options && options.windows) => {
  const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
  return regex.test(utils.basename(input, { windows: posix }));
};
```

Minimal change; no behavior change for POSIX paths.

## Tests

Added cases under `options.matchBase` in `test/options.js` covering backslash-separated paths with `{ matchBase: true, windows: true }` and a direct `matchBase(..., { windows: true })` call. Verified they **fail without** the fix and **pass with** it. Full suite green (`npm run mocha` → 1977 passing) and `npm run lint` clean.
