### PR TITLE
fix: negate `[!...]` bracket expressions like `[^...]`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -718,7 +718,9 @@ const parse = (input, options) => {
         value = `\\${value}`;
       }
 
-      if (opts.posix === true && value === '!' && prev.value === '[') {
+      // A leading `!` inside a bracket expression negates it, like `^` (POSIX
+      // 2.13.1, Bash). `[!a]` is equivalent to `[^a]`, independent of `posix`.
+      if (value === '!' && prev.value === '[') {
         value = '^';
       }
 

--- a/test/brackets.js
+++ b/test/brackets.js
@@ -4,6 +4,23 @@ const assert = require('assert');
 const { isMatch } = require('..');
 
 describe('brackets', () => {
+  describe('POSIX `[!...]` negation', () => {
+    it('should negate a bracket expression with a leading `!`, like `[^...]`', () => {
+      assert(!isMatch('a', '[!a]'));
+      assert(isMatch('b', '[!a]'));
+      assert(!isMatch('b', '[!a-c]'));
+      assert(isMatch('d', '[!a-c]'));
+      assert(!isMatch('a', '[!abc]'));
+      assert(isMatch('aXc', 'a[!b]c'));
+      assert(!isMatch('abc', 'a[!b]c'));
+    });
+
+    it('should treat `!` as a literal when it is not the first bracket character', () => {
+      assert(isMatch('!', '[a!]'));
+      assert(isMatch('a', '[a!]'));
+    });
+  });
+
   describe('trailing stars', () => {
     it('should support stars following brackets', () => {
       assert(isMatch('a', '[a]*'));


### PR DESCRIPTION
A leading `!` inside a bracket expression is a negation operator, equivalent to `^` (POSIX 2.13.1, Bash 4.3). picomatch honors `[^...]` but leaves `[!...]` un-negated, treating `!` as a literal class member:

```js
picomatch.isMatch("a", "[!a]")    // true,  expected false
picomatch.isMatch("b", "[!a]")    // false, expected true
picomatch.isMatch("d", "[!a-c]")  // false, expected true
```

Bash and `minimatch` both negate here. The `!`→`^` conversion in `lib/parse.js` was gated behind `opts.posix === true`, but single-`!` negation is core glob syntax (the `posix` option is documented for *named* classes like `[:alpha:]`), and `[^...]` already works without the flag.

Removing the gate makes `[!a]` compile to the same negated class as `[^a]`. The `prev.value === "["` guard keeps a non-leading `!` literal (`[a!]` is unchanged). Full suite stays at **1975 passing** with no regressions; added bracket-negation tests.