### PR TITLE
fix: treat `**` adjacent to a literal as a single star (#99)

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1365,6 +1365,11 @@ parse.fastpaths = (input, options) => {
         const match = /^(.*?)\.(\w+)$/.exec(str);
         if (!match) return;
 
+        // A bare `**` here is adjacent to a literal extension in the same path
+        // segment (e.g. `**.js`), so it must act as a single star rather than a
+        // globstar. Bail out of the fast path and let the full parser handle it.
+        if (match[1] === '**') return;
+
         const source = create(match[1]);
         if (!source) return;
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1408,6 +1408,11 @@ parse.fastpaths = (input, options) => {
         const match = /^(.*?)\.(\w+)$/.exec(str);
         if (!match) return;
 
+        // A bare `**` here is adjacent to a literal extension in the same path
+        // segment (e.g. `**.js`), so it must act as a single star rather than a
+        // globstar. Bail out of the fast path and let the full parser handle it.
+        if (match[1] === '**') return;
+
         const source = create(match[1]);
         if (!source) return;
 

--- a/test/issue-related.js
+++ b/test/issue-related.js
@@ -61,4 +61,16 @@ describe('issue-related tests', () => {
     assert(isMatch('a/foo.js', '**/foo.js', { dot: true }));
     assert(isMatch('foo.js', '**/foo.js', { dot: true }));
   });
+
+  it('should treat a leading `**` followed by a literal as a single star (picomatch/issues#99)', () => {
+    // `**` only acts as a globstar when it is the sole content of a path segment.
+    // When it is adjacent to other characters in the same segment (here `.thing.js`),
+    // it must behave like a single star and not match across path separators.
+    assert(!isMatch('somepath/test.thing.js', '**.thing.js'));
+    assert(!isMatch('a/b/c.js', '**.js'));
+    // these sibling cases already behaved correctly and must keep working
+    assert(!isMatch('somepath/test.dash-thing.js', '**.dash-thing.js'));
+    assert(isMatch('test.thing.js', '**.thing.js'));
+    assert(isMatch('somepath/test.thing.js', '**/*.thing.js'));
+  });
 });

--- a/test/issue-related.js
+++ b/test/issue-related.js
@@ -72,4 +72,16 @@ describe('issue-related tests', () => {
     assert(!isMatch('test/utils', 'test(/utils/**)', { strictSlashes: true }));
     assert(!isMatch('test/utils', 'test(/utils/**)/file'));
   });
+
+  it('should treat a leading `**` followed by a literal as a single star (picomatch/issues#99)', () => {
+    // `**` only acts as a globstar when it is the sole content of a path segment.
+    // When it is adjacent to other characters in the same segment (here `.thing.js`),
+    // it must behave like a single star and not match across path separators.
+    assert(!isMatch('somepath/test.thing.js', '**.thing.js'));
+    assert(!isMatch('a/b/c.js', '**.js'));
+    // these sibling cases already behaved correctly and must keep working
+    assert(!isMatch('somepath/test.dash-thing.js', '**.dash-thing.js'));
+    assert(isMatch('test.thing.js', '**.thing.js'));
+    assert(isMatch('somepath/test.thing.js', '**/*.thing.js'));
+  });
 });


### PR DESCRIPTION
## Description

`picomatch('**.thing.js')('somepath/test.thing.js')` returns `true` but should return `false`. Per Bash semantics (confirmed by @jonschlinkert in #99), `**` only acts as a globstar when it is the *sole* content of a path segment. When `**` is adjacent to other characters in the same segment (here `.thing.js`), it must behave like a single `*` and must not match across path separators.

Closes #99.

## Root cause

The bug is in the fast-path builder `parse.fastpaths` (`lib/parse.js`). Its `create()` helper strips a trailing `.ext` in the `default` branch and recurses on the remaining base. For `**.thing.js` the base is reduced to a bare `**`, which hits the `case '**'` branch and expands to a **globstar** (`(?:(?!...).)*?`) that crosses `/`.

Patterns like `**.dash-thing.js` were unaffected only by accident: `-` is not a `\w` character, so they never matched the `.ext` fast path and fell back to the full parser, which already produces the correct single-star regex.

## Fix

In the `default` branch, if stripping the extension reduces the base to a bare `**`, bail out of the fast path (`return`) and let the full parser handle the pattern — exactly the path that already produced correct output for `**.dash-thing.js`. This keeps the change minimal and guarantees the fast path agrees with the full parser.

## Tests

Added a regression test in `test/issue-related.js`. The full suite passes (`npm test`): 1976 passing, including the existing globstar / "non-exclusive double-stars" specs.
