### PR TITLE
fix: preserve all branches when rewriting risky repeated extglobs

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -230,7 +230,15 @@ const parseRepeatedExtglob = (pattern, requireEnd = true) => {
   }
 };
 
-const getStarExtglobSequenceOutput = pattern => {
+const buildCharClassStar = chars => {
+  const source = chars.length === 1
+    ? utils.escapeRegex(chars[0])
+    : `[${chars.map(ch => utils.escapeRegex(ch)).join('')}]`;
+
+  return `${source}*`;
+};
+
+const getStarExtglobSequenceChars = pattern => {
   let index = 0;
   const chars = [];
 
@@ -259,11 +267,7 @@ const getStarExtglobSequenceOutput = pattern => {
     return;
   }
 
-  const source = chars.length === 1
-    ? utils.escapeRegex(chars[0])
-    : `[${chars.map(ch => utils.escapeRegex(ch)).join('')}]`;
-
-  return `${source}*`;
+  return chars;
 };
 
 const repeatedExtglobRecursion = pattern => {
@@ -302,15 +306,41 @@ const analyzeRepeatedExtglob = (body, options) => {
     }
   }
 
+  // A repeated extglob is "risky" (prone to catastrophic backtracking) when a
+  // branch is itself a `*(...)` sequence, since that nests an unbounded quantifier
+  // inside the outer `+(...)`/`*(...)`. When *every* branch reduces to single
+  // characters we can emit one flat, ReDoS-safe character class that preserves the
+  // meaning of ALL branches (e.g. `+(*(a)|*(b))` -> `[ab]*`), rather than dropping
+  // every branch but the first.
+  const safeChars = [];
+  let sawStarSequence = false;
+  let combinable = true;
+
   for (const branch of branches) {
-    const safeOutput = getStarExtglobSequenceOutput(branch);
-    if (safeOutput) {
-      return { risky: true, safeOutput };
+    const chars = getStarExtglobSequenceChars(branch);
+    if (chars) {
+      sawStarSequence = true;
+      safeChars.push(...chars);
+      continue;
     }
+
+    const literal = normalizeSimpleBranch(branch);
+    if (literal && literal.length === 1) {
+      safeChars.push(literal);
+      continue;
+    }
+
+    combinable = false;
 
     if (repeatedExtglobRecursion(branch) > max) {
       return { risky: true };
     }
+  }
+
+  if (sawStarSequence) {
+    return combinable
+      ? { risky: true, safeOutput: buildCharClassStar([...new Set(safeChars)]) }
+      : { risky: true };
   }
 
   return { risky: false };

--- a/test/options.maxExtglobRecursion.js
+++ b/test/options.maxExtglobRecursion.js
@@ -93,6 +93,30 @@ describe('options.maxExtglobRecursion', () => {
     assert(isMatch('fff', '*(*(f))'));
   });
 
+  it('should rewrite multi-branch star-only repeated extglobs without dropping branches', () => {
+    // Regression: the risky-extglob rewrite previously emitted only the first
+    // branch, so `+(*(a)|*(b))` collapsed to `a*` and silently stopped matching
+    // any string containing `b`. The safe rewrite must preserve every branch.
+    assert.strictEqual(
+      makeRe('+(*(a)|*(b))').source,
+      '^(?:(?=.)[ab]*)$'
+    );
+    assert.strictEqual(
+      makeRe('*(*(a)|c)').source,
+      '^(?:(?=.)[ac]*)$'
+    );
+
+    for (const str of ['a', 'b', 'ab', 'ba', 'aabb']) {
+      assert(isMatch(str, '+(*(a)|*(b))'), `expected to match ${str}`);
+    }
+    assert(!isMatch('c', '+(*(a)|*(b))'));
+
+    for (const str of ['c', 'a', 'aca', 'cac']) {
+      assert(isMatch(str, '*(*(a)|c)'), `expected to match ${str}`);
+    }
+    assert(!isMatch('d', '*(*(a)|c)'));
+  });
+
   it('should preserve capture behavior for rewritten repeated extglobs', () => {
     const embedded = makeRe('foo/+(a|aa)/bar', { capture: true });
     assert.strictEqual(embedded.source, '^(?:foo\\/\\+\\(a\\|aa\\)\\/bar)$');


### PR DESCRIPTION
## Summary

A multi-branch repeated extglob (e.g. `+(*(a)|*(b))`) is compiled incorrectly: every alternation branch except the first is silently dropped, so the pattern matches far fewer strings than it should. This is a correctness regression introduced in `4.0.4` — the same patterns match correctly in `2.3.1` through `4.0.3`.

## Reproduction

```js
const picomatch = require('picomatch');

picomatch.isMatch('b',  '+(*(a)|*(b))'); // => false  (expected: true)
picomatch.isMatch('ab', '+(*(a)|*(b))'); // => false  (expected: true)
picomatch.isMatch('c',  '*(*(a)|c)');    // => false  (expected: true)

picomatch.makeRe('+(*(a)|*(b))').source;
// => '^(?:(?=.)a*)$'          the `|*(b)` branch is gone
// expected: '^(?:(?=.)[ab]*)$'
```

For comparison, the generated source across versions:

| picomatch | `makeRe('+(*(a)|*(b))').source`      | `isMatch('b', …)` |
| --------- | ----------------------------------- | ----------------- |
| 2.3.1     | `^(?:(?=.)(?:(?:a)*\|(?:b)*)+)$`     | `true`            |
| 4.0.3     | `^(?:(?=.)(?:(?:a)*\|(?:b)*)+)$`     | `true`            |
| 4.0.4     | `^(?:(?=.)a*)$`                      | `false`           |

## Root cause

`4.0.4` added a ReDoS safeguard that rewrites a repeated extglob whose branch is itself a `*(…)` sequence (which would otherwise nest an unbounded quantifier and enable catastrophic backtracking). In `analyzeRepeatedExtglob`, that rewrite bailed out on the **first** matching branch:

```js
for (const branch of branches) {
  const safeOutput = getStarExtglobSequenceOutput(branch);
  if (safeOutput) {
    return { risky: true, safeOutput }; // <-- returns first branch, drops the rest
  }
  // ...
}
```

`extglobClose` then emitted only that single branch's output, discarding `|*(b)`.

## Fix

Collect the single-character set from **every** branch and emit one flat character class (`[ab]*`) that preserves the meaning of all branches:

- `+(*(a)|*(b))` → `[ab]*`
- `*(*(a)|c)` → `[ac]*`

The result is a single, un-nested quantifier over a character class, so the ReDoS safeguard is fully retained — an adversarial input (`'a'.repeat(50000) + '!'`) is rejected in well under a millisecond. When a branch cannot be reduced to single characters, the existing literalize fallback is used unchanged, so no previously-guarded pattern becomes risky again.

Single-branch behavior is unchanged (`*(*(f)*(o))` still compiles to `[fo]*`, `+(*(a))` still compiles to `a*`).

## Tests

Adds regression coverage in `test/options.maxExtglobRecursion.js` for the multi-branch case, asserting both the generated source and match behavior:

```js
it('should rewrite multi-branch star-only repeated extglobs without dropping branches', () => {
  assert.strictEqual(makeRe('+(*(a)|*(b))').source, '^(?:(?=.)[ab]*)$');
  assert.strictEqual(makeRe('*(*(a)|c)').source, '^(?:(?=.)[ac]*)$');

  for (const str of ['a', 'b', 'ab', 'ba', 'aabb']) {
    assert(isMatch(str, '+(*(a)|*(b))'), `expected to match ${str}`);
  }
  assert(!isMatch('c', '+(*(a)|*(b))'));

  for (const str of ['c', 'a', 'aca', 'cac']) {
    assert(isMatch(str, '*(*(a)|c)'), `expected to match ${str}`);
  }
  assert(!isMatch('d', '*(*(a)|c)'));
});
```

The full suite passes (`1976 passing`), including the existing `options.maxExtglobRecursion` and `malicious` (ReDoS) tests.
