### PR TITLE
fix: honor the windows option when matching basenames

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -157,9 +157,9 @@ picomatch.test = (input, regex, options, { glob, posix } = {}) => {
  * @api public
  */
 
-picomatch.matchBase = (input, glob, options) => {
+picomatch.matchBase = (input, glob, options, posix = options && options.windows) => {
   const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
-  return regex.test(utils.basename(input));
+  return regex.test(utils.basename(input, { windows: posix }));
 };
 
 /**

--- a/test/options.js
+++ b/test/options.js
@@ -21,6 +21,16 @@ describe('options', () => {
       assert(isMatch('./x/y.js', '**/*.js', { matchBase: true, windows: true }));
       assert(!isMatch('./x/y.js', '!**/*.js', { matchBase: true, windows: true }));
     });
+
+    it('should split the basename on backslashes when the windows option is enabled', () => {
+      // Regression: matchBase/basename ignored the `windows` option and split
+      // only on `/`, so a backslash-separated path yielded the wrong basename.
+      assert(isMatch('foo\\bar.js', 'bar.js', { basename: true, windows: true }));
+      assert(isMatch('a\\b\\c\\d.md', '*.md', { matchBase: true, windows: true }));
+      assert(isMatch('x\\y\\acb', 'a?b', { matchBase: true, windows: true }));
+      assert(!isMatch('x\\y\\acb', 'a?z', { matchBase: true, windows: true }));
+      assert(isMatch('a/b\\c.js', '*.js', { matchBase: true, windows: true }));
+    });
   });
 
   describe('options.flags', () => {


### PR DESCRIPTION
## Summary

With `{ windows: true }`, `matchBase` / `basename` matching uses the wrong basename for backslash-separated paths, because the `windows` flag is never forwarded to `utils.basename`. As a result, matches that should succeed return `false`.

## Reproduction

```js
const picomatch = require('picomatch');

picomatch.isMatch('foo\\bar.js', 'bar.js', { basename: true, windows: true });
// => false  (expected: true)

picomatch.isMatch('x\\y\\acb', 'a?b', { matchBase: true, windows: true });
// => false  (expected: true)
```

`utils.basename` already handles the `windows` option correctly — it is simply never given it:

```js
const utils = require('picomatch/lib/utils');
utils.basename('foo\\bar.js', { windows: true }); // => 'bar.js'  (correct)
utils.basename('foo\\bar.js');                    // => 'foo\\bar.js'  (what matchBase used)
```

## Root cause

`picomatch.test` already passes the windows flag to `matchBase` as a fourth argument:

```js
match = picomatch.matchBase(input, regex, options, posix); // posix === opts.windows
```

but `matchBase`'s signature never declared that parameter, so it was dropped, and the basename was computed with the default separator (`/` only):

```js
picomatch.matchBase = (input, glob, options) => {
  const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
  return regex.test(utils.basename(input)); // <-- no { windows }
};
```

## Fix

Accept the flag and forward it to `utils.basename`, defaulting to `options.windows` so direct callers of the public `matchBase` API get the same behavior:

```js
picomatch.matchBase = (input, glob, options, posix = options && options.windows) => {
  const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
  return regex.test(utils.basename(input, { windows: posix }));
};
```

Forward-slash paths are unaffected. This aligns `matchBase` with the documented `windows` option ("Also accept backslashes as the path separator") and with `utils.basename`'s existing `windows` support.

## Tests

Adds a regression test in `test/options.js` covering backslash-separated paths under `matchBase` / `basename` with `{ windows: true }`. The full suite passes (`1976 passing`).
