### PR TITLE
Treat a leading "!" in a bracket expression as negation by default

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -748,7 +748,7 @@ const parse = (input, options) => {
         value = `\\${value}`;
       }
 
-      if (opts.posix === true && value === '!' && prev.value === '[') {
+      if (value === '!' && prev.value === '[') {
         value = '^';
       }
 

--- a/test/brackets.js
+++ b/test/brackets.js
@@ -23,4 +23,44 @@ describe('brackets', () => {
       assert(!isMatch('a/b', '[a]*'));
     });
   });
+  describe('negation with "!"', () => {
+    it('should negate a bracket expression with a leading "!"', () => {
+      assert(!isMatch('a', '[!abc]'));
+      assert(!isMatch('b', '[!abc]'));
+      assert(!isMatch('c', '[!abc]'));
+      assert(isMatch('d', '[!abc]'));
+      assert(isMatch('x', '[!abc]'));
+    });
+
+    it('should negate ranges with a leading "!"', () => {
+      assert(!isMatch('a', '[!a-c]'));
+      assert(!isMatch('c', '[!a-c]'));
+      assert(isMatch('d', '[!a-c]'));
+    });
+
+    it('should agree with "^" negation', () => {
+      assert.strictEqual(isMatch('a', '[!abc]'), isMatch('a', '[^abc]'));
+      assert.strictEqual(isMatch('d', '[!abc]'), isMatch('d', '[^abc]'));
+      assert.strictEqual(isMatch('a', '[!a-c]'), isMatch('a', '[^a-c]'));
+      assert.strictEqual(isMatch('d', '[!a-c]'), isMatch('d', '[^a-c]'));
+    });
+
+    it('should negate within a larger pattern', () => {
+      assert(!isMatch('abc', 'a[!b]c'));
+      assert(isMatch('axc', 'a[!b]c'));
+      assert(!isMatch('ad', '[!abc]d'));
+      assert(isMatch('xd', '[!abc]d'));
+    });
+
+    it('should treat "!" as a literal when it is not leading', () => {
+      assert(isMatch('!', '[a!]'));
+      assert(isMatch('a', '[a!]'));
+      assert(!isMatch('b', '[a!]'));
+    });
+
+    it('should negate a literal "!"', () => {
+      assert(!isMatch('!', '[!!]'));
+      assert(isMatch('a', '[!!]'));
+    });
+  });
 });


### PR DESCRIPTION
Fixes #187.

The `[!` to `[^` conversion in `lib/parse.js` was gated on `options.posix`, so by default `!` was emitted as an ordinary class member and `[!abc]` matched exactly the characters it is meant to exclude:

```js
pm.isMatch('a', '[!abc]')  // was true
pm.isMatch('d', '[!abc]')  // was false
```

```diff
-      if (opts.posix === true && value === '!' && prev.value === '[') {
+      if (value === '!' && prev.value === '[') {
```

Three reasons the gate looks wrong rather than deliberate:

- `[!...]` is Bash pattern negation, not a POSIX bracket expression like `[[:alpha:]]`
- `[[:alpha:]]` already works with `posix` off, so the flag was not gating the feature it is named for
- `[^...]` negation was already unconditional, so the two negation forms disagreed with each other by default

`makeRe('[!abc]')` now produces `^(?:[^abc/]\/?)$`, the same shape as `[^abc]`.

## Compatibility

This changes default behaviour, so I measured it rather than assuming.

**Existing suite:** 1977 passing before, 1977 passing after, with no test edited. Nothing pinned the old behaviour; every existing `[!` test is in `posix-classes.js` and already runs with `posix: true`.

**Against minimatch**, over a 462-case matrix of 21 bracket patterns by 22 inputs:

| | agree | disagree |
|---|---|---|
| before | 376 | 86 |
| after | **441** | **21** |

65 disagreements fixed, none introduced. The 21 that remain are pre-existing picomatch behaviours unrelated to this change: leading-dot handling and `/` inside classes. Both also apply to `[^...]`, which this does not touch, and they are unchanged by the patch.

## Tests

Six cases added to `test/brackets.js`: plain negation, ranges, parity with `[^...]`, negation inside a larger pattern, `!` as a literal when not leading (`[a!]`), and a negated literal `!` (`[!!]`). Reverting `lib/parse.js` and keeping the tests fails five of them.
