### PR TITLE
fix: negated patterns with slashes incorrectly use basename-only matching when matchBase is true

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -146,7 +146,19 @@ picomatch.test = (input, regex, options, { glob, posix } = {}) => {
 
   if (match === false || opts.capture === true) {
     if (opts.matchBase === true || opts.basename === true) {
-      match = picomatch.matchBase(input, regex, options, posix);
+      const globStr = glob || '';
+      const negated = globStr.startsWith('!');
+      const withoutNegation = negated ? globStr.replace(/^!+/, '') : globStr;
+      if (negated && (withoutNegation.includes('/') || withoutNegation.includes('\\'))) {
+        // For negated patterns with slashes, test both the full path and the
+        // basename.  If either method detects a positive match (returns falsy),
+        // the negation should yield isMatch = false.
+        const fullMatch = regex.exec(output);
+        const baseMatch = picomatch.matchBase(input, regex, options, posix);
+        match = fullMatch && baseMatch ? fullMatch : null;
+      } else {
+        match = picomatch.matchBase(input, regex, options, posix);
+      }
     } else {
       match = regex.exec(output);
     }

--- a/test/options.js
+++ b/test/options.js
@@ -22,6 +22,15 @@ describe('options', () => {
       assert(!isMatch('./x/y.js', '!**/*.js', { matchBase: true, windows: true }));
     });
 
+    it('should correctly negate patterns with slashes when matchBase is true (issue #136)', () => {
+      const opts = { matchBase: true, dot: true };
+      assert(!isMatch('packages/pkg-2/examples/.eslintrc.yaml', '!**/examples/**', opts));
+      assert(!isMatch('packages/pkg-2/examples/do-a-thing/index.js', '!**/examples/**', opts));
+      assert(!isMatch('packages/pkg-2/examples/and-another-thing/package.json', '!**/examples/**', opts));
+      // Non-matching paths should still pass the negation
+      assert(isMatch('packages/pkg-2/src/index.js', '!**/examples/**', opts));
+    });
+
     it('should split the basename on backslashes when the windows option is enabled', () => {
       // Regression: matchBase/basename ignored the `windows` option and split
       // only on `/`, so a backslash-separated path yielded the wrong basename.


### PR DESCRIPTION
Fixes #136

## Problem

When `matchBase: true` is set, `picomatch.test()` unconditionally tests the compiled regex against the **basename** of the input path. For negated patterns containing path separators (e.g. `!**/examples/**`), this produces incorrect results because the negative lookahead regex cannot detect directory structure from the basename alone.

**Reproduction:**
```js
const pm = require('picomatch');
const opts = { matchBase: true, dot: true };

pm.isMatch('packages/pkg-2/examples/.eslintrc.yaml', '!**/examples/**', opts);
// Actual: true (WRONG - path IS inside examples/)
// Expected: false
```

## Root cause

In `picomatch.test()`, when `matchBase` is true, the code calls `picomatch.matchBase()` which tests the regex against `utils.basename(input)` only. For the negated regex `^(?!^(?:...examples...)$).*$` tested against basename `.eslintrc.yaml`, the positive pattern doesn't match the basename, so the negative lookahead passes and the result is incorrectly `true`.

## Fix

For negated patterns whose glob (after stripping the `!` prefix) contains a path separator (`/` or `\`), the fix now tests **both** the full path (`regex.exec(output)`) and the basename (`matchBase`). If either method detects that the positive pattern matches, the overall result is non-matching (`null`). This ensures:
- Directory-structure negation patterns like `!**/examples/**` correctly reject paths inside `examples/`
- Basename-oriented negation patterns like `!**/*.js` continue to work (the basename test catches cases where the full-path regex misses due to `./` prefix handling)

## Test results

- **Baseline (clean checkout):** 1977 passing, 0 failing
- **After fix:** 1978 passing, 0 failing (+1 new regression test)
- No regressions introduced

## Compatibility

This change only affects negated patterns that contain path separators when `matchBase` is enabled. Non-negated patterns and slash-free patterns are completely unaffected.