### PR TITLE
fix: treat `?` and `+` after a closing extglob as glob tokens

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -431,6 +431,9 @@ const parse = (input, options) => {
   len = input.length;
 
   const extglobs = [];
+  // Paren depths of groups opened by `@`, which are tokenized as plain parens
+  // rather than going through extglobOpen/extglobClose.
+  const atParens = [];
   const braces = [];
   const stack = [];
   let prev = bos;
@@ -470,6 +473,17 @@ const parse = (input, options) => {
     state.negated = true;
     state.start++;
     return true;
+  };
+
+  /**
+   * True when the previous token is the `)` that closes an extglob.
+   * A metacharacter following one is a glob token, not a regex quantifier,
+   * unless the `regex` option is enabled. This is the same rule the star
+   * handler applies to `)*` and `]*`.
+   */
+
+  const afterExtglob = () => {
+    return opts.regex !== true && prev.type === 'paren' && prev.extglob === true && prev.value === ')';
   };
 
   const increment = type => {
@@ -787,6 +801,7 @@ const parse = (input, options) => {
 
     if (value === '(') {
       increment('parens');
+      if (prev.type === 'at') atParens.push(state.parens);
       push({ type: 'paren', value });
       continue;
     }
@@ -802,7 +817,10 @@ const parse = (input, options) => {
         continue;
       }
 
-      push({ type: 'paren', value, output: state.parens ? ')' : '\\)' });
+      const isAtGroup = atParens[atParens.length - 1] === state.parens;
+      if (isAtGroup) atParens.pop();
+
+      push({ type: 'paren', extglob: isAtGroup, value, output: state.parens ? ')' : '\\)' });
       decrement('parens');
       continue;
     }
@@ -1025,7 +1043,7 @@ const parse = (input, options) => {
         continue;
       }
 
-      if (prev && prev.type === 'paren') {
+      if (prev && prev.type === 'paren' && !afterExtglob()) {
         const next = peek();
         let output = value;
 
@@ -1074,7 +1092,7 @@ const parse = (input, options) => {
         continue;
       }
 
-      if ((prev && prev.value === '(') || opts.regex === false) {
+      if ((prev && prev.value === '(') || opts.regex === false || afterExtglob()) {
         push({ type: 'plus', value, output: PLUS_LITERAL });
         continue;
       }

--- a/test/extglobs.js
+++ b/test/extglobs.js
@@ -338,6 +338,90 @@ describe('extglobs', () => {
     });
   });
 
+  describe('metacharacters following a closing paren', () => {
+    // A `?` or `+` after a closing extglob is a glob token, not a regex quantifier.
+    // Expectations below match `bash 3.2` with `shopt -s extglob`.
+
+    it('should treat `?` after an extglob as a single character wildcard', () => {
+      assert(isMatch('ab', '@(a|b)?'));
+      assert(isMatch('ax', '@(a|b)?'));
+      assert(!isMatch('a', '@(a|b)?'));
+      assert(!isMatch('b', '@(a|b)?'));
+
+      assert(isMatch('b', '*(a)?'));
+      assert(isMatch('aa', '*(a)?'));
+      assert(isMatch('+', '*(a)?'));
+      assert(!isMatch('abc', '*(a)?'));
+
+      assert(isMatch('aa', '+(a)?'));
+      assert(isMatch('aaa', '+(a)?'));
+      assert(!isMatch('a', '+(a)?'));
+
+      assert(isMatch('a', '?(a)?'));
+      assert(isMatch('aa', '?(a)?'));
+      assert(!isMatch('aaa', '?(a)?'));
+    });
+
+    it('should treat `?` after an extglob as a wildcard mid-pattern', () => {
+      assert(isMatch('abz', '@(a)?z'));
+      assert(!isMatch('az', '@(a)?z'));
+      assert(isMatch('abbc', 'a@(b)?c'));
+      assert(!isMatch('abc', 'a@(b)?c'));
+    });
+
+    it('should treat `+` after an extglob as a literal plus', () => {
+      assert(isMatch('a+', '@(a|b)+'));
+      assert(!isMatch('aa', '@(a|b)+'));
+
+      assert(isMatch('a+', '*(a)+'));
+      assert(isMatch('+', '*(a)+'));
+      assert(!isMatch('aa', '*(a)+'));
+
+      assert(isMatch('a+', '+(a)+'));
+      assert(!isMatch('+', '+(a)+'));
+
+      assert(isMatch('a+', '?(a)+'));
+      assert(isMatch('+', '?(a)+'));
+      assert(!isMatch('aa', '?(a)+'));
+    });
+
+    it('should not compile an extglob followed by `+` to an empty regex', () => {
+      // `(?:a)?+` and friends are invalid in JavaScript, and compileRe swallowed
+      // the SyntaxError into /$^/, a regex that matches nothing at all.
+      for (const pattern of ['*(a)+', '+(a)+', '?(a)+']) {
+        assert.notStrictEqual(makeRe(pattern).source, '$^', pattern);
+      }
+    });
+
+    it('should still expand `*` after an extglob', () => {
+      assert(isMatch('a', '@(a|b)*'));
+      assert(isMatch('abc', '@(a|b)*'));
+      assert(!isMatch('c', '@(a|b)*'));
+    });
+
+    it('should start a new extglob when `(` follows', () => {
+      assert(isMatch('ac', '@(a|b)?(c)'));
+      assert(isMatch('a', '@(a|b)?(c)'));
+      assert(isMatch('ac', '@(a|b)+(c)'));
+      assert(!isMatch('a', '@(a|b)+(c)'));
+    });
+
+    it('should use regex quantifiers when the `regex` option is true', () => {
+      const opts = { regex: true };
+      assert(isMatch('a', '@(a|b)?', opts));
+      assert(isMatch('aa', '@(a|b)+', opts));
+      assert(!isMatch('a+', '@(a|b)+', opts));
+    });
+
+    it('should not change quantifiers on plain regex groups', () => {
+      // `(a|b)` is a capture group, not an extglob, so `?` and `+` stay quantifiers.
+      assert.strictEqual(makeRe('(a|b)?').source, '^(?:(a|b)?)$');
+      assert.strictEqual(makeRe('(a|b)+').source, '^(?:(a|b)+)$');
+      assert(isMatch('a', '(a|b)?'));
+      assert(isMatch('aa', '(a|b)+'));
+    });
+  });
+
   it('should match nested directories with negation extglobs', () => {
     assert(isMatch('a', '!(a/**)'));
     assert(!isMatch('a/', '!(a/**)'));


### PR DESCRIPTION
A `?` or `+` that follows a closing extglob is passed straight through to the generated regex, where it binds to the preceding group as a quantifier instead of being treated as a glob token.

```js
picomatch.makeRe('@(a|b)?')  // ^(?:(a|b)?)$        the group becomes optional
picomatch.makeRe('*(a)?')    // ^(?:(?=.)(?:a)*?)$  the star becomes lazy
picomatch.makeRe('+(a)?')    // ^(?:(?=.)(?:a)+?)$
picomatch.makeRe('?(a)+')    // $^
```

The last one is the worst case. `(?:a)?+` is not valid JavaScript, so `compileRe` catches the `SyntaxError` and falls back to `/$^/`. Nothing is thrown and nothing is logged; `?(a)+`, `*(a)+` and `+(a)+` simply match nothing at all.

```js
picomatch.isMatch('a+', '?(a)+')  // false, bash matches
picomatch.isMatch('b',  '@(a|b)?')  // true, bash does not match
picomatch.isMatch('ab', '@(a|b)?')  // false, bash matches
```

For reference:

```
$ shopt -s extglob
$ [[ a+ == ?(a)+ ]]   && echo match   # match
$ [[ b == @(a|b)? ]]  && echo match   # no output
$ [[ ab == @(a|b)? ]] && echo match   # match
```

## Why `*` is already correct

The star handler in `parse.js` only uses regex semantics after a closing paren or bracket when the caller asks for it:

```js
if (prev && (prev.type === 'bracket' || prev.type === 'paren') && opts.regex === true) {
```

which is what the `regex` option is documented to control:

> Use regular expression rules for `+` (instead of matching literal `+`), and for stars that follow closing parentheses or brackets (as in `)*` and `]*`).

So `@(a|b)*` is right today. `?` and `+` never got that check, so they always take the regex branch. This PR applies the same rule to them: after a closing extglob, `?` is a single character wildcard and `+` is a literal plus, unless `options.regex` is true.

## Scope

Only extglobs change. `(a|b)?` and `(a|b)+` are ordinary capture groups and keep their quantifiers, so this does not touch the ambiguity raised in #101, which is about plain parens and looked to be blocked on how many tests depend on the current behaviour. There is a test pinning that.

`@(...)` needed a little care. Unlike the other four, it is tokenized as an `at` token followed by plain parens, so its closing `)` is indistinguishable from a capture group's. The patch records the paren depth of a group opened by `@` and marks the matching `)` as an extglob, which is what lets `@(a|b)?` and `(a|b)?` be told apart.

`!(...)` composed with a trailing token still diverges from bash for a separate reason. Its negative lookahead is only `$`-anchored when the extglob ends the pattern, so `!(a)?` rejects anything starting with `a` rather than anything that is exactly `a`. That is the same mechanism as #154 and #93 and I have left it alone.

## Verification

`npm test`: 1985 passing, up from 1977. The four new bug-covering tests fail on `main`; the four guard tests (`*` unchanged, `?(`/`+(` still opening a nested extglob, `regex: true` opt-out, plain groups unchanged) pass both before and after. `npm run lint` is clean.

I found this by differentially testing against `bash 3.2` with `shopt -s extglob`, generating pattern/subject pairs from a small extglob grammar. Subjects are slash-free so bash's fnmatch semantics line up, and I excluded the two known divergences (a leading `!` is picomatch negation, and `[!...]` is #187). Over 20,000 seeded pairs:

| | disagreements with bash | distinct patterns |
|---|---|---|
| 4.0.5 | 927 | 404 |
| this PR | 40 | 20 |

The 40 that remain are other classes, mostly an extglob that can match empty following a `*` (`*?(a)`, `*@(a|)`) and the `!(...)` anchoring above. Happy to look at those separately.

I also ran micromatch's suite against a picomatch carrying the equivalent change, since it is the largest consumer: 1954 passing, unchanged.
