### PR TITLE
fix: star opening a brace at a segment start should not match dotfiles

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1260,7 +1260,38 @@ const parse = (input, options) => {
       continue;
     }
 
-    if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+    // A `*` that opens a brace alternation (`{*,…}` or `{…,*}`) inherits the
+    // dotfile guard when the brace group itself begins a path segment, because
+    // brace expansion happens before globbing: `{*.js,x}` behaves like `*.js`,
+    // which must not match a leading dot. A `*` mid-segment (`a{*,b}`) keeps
+    // matching dots, so the brace group's position is what matters.
+    let isBraceSegmentStart = false;
+    if (state.braces > 0 && (prev.type === 'brace' || prev.type === 'comma')) {
+      // Walk outward through nested braces: the group begins a path segment only
+      // if every enclosing brace is grounded at a segment boundary. A brace that
+      // is itself the start of an outer alternative (preceded by a comma or `{`)
+      // defers the decision to that outer brace; a brace preceded by literal
+      // content (e.g. `a{*,b}`) means the star is mid-segment.
+      isBraceSegmentStart = true;
+      for (let b = braces.length - 1; b >= 0; b--) {
+        const beforeBrace = state.tokens[braces[b].tokensIndex - 1];
+        if (!beforeBrace || beforeBrace.type === 'slash' || beforeBrace.type === 'bos') {
+          break;
+        }
+        if (beforeBrace.type === 'comma' || beforeBrace.type === 'brace') {
+          continue;
+        }
+        isBraceSegmentStart = false;
+        break;
+      }
+    }
+
+    if (
+      state.index === state.start ||
+      prev.type === 'slash' ||
+      prev.type === 'dot' ||
+      isBraceSegmentStart
+    ) {
       if (prev.type === 'dot') {
         state.output += NO_DOT_SLASH;
         prev.output += NO_DOT_SLASH;

--- a/test/dotfiles.js
+++ b/test/dotfiles.js
@@ -13,6 +13,19 @@ describe('dotfiles', () => {
       assert.deepStrictEqual(match(['a/b', 'a/.b', '.a/b', '.a/.b'], '**'), ['a/b']);
       assert.deepStrictEqual(match(['a/b/c/.dotfile'], '*.*'), []);
     });
+
+    it('should not match dotfiles with a star that opens a brace at a segment start:', () => {
+      // Brace expansion happens before globbing, so `{*.js,x}` behaves like
+      // `*.js` and must not match a leading-dot file.
+      assert.deepStrictEqual(match(['.js', 'a.js'], '{*.js,x}'), ['a.js']);
+      assert.deepStrictEqual(match(['.foo', 'foo'], '{*,x}'), ['foo']);
+      assert.deepStrictEqual(match(['.foo', 'bar'], '{a,*}'), ['bar']);
+      assert.deepStrictEqual(match(['foo/.js', 'foo/a.js'], 'foo/{*.js,x}'), ['foo/a.js']);
+      assert.deepStrictEqual(match(['.js', 'a.js'], '{a,{*.js,b}}'), ['a.js']);
+      // A star that is mid-segment (not at the brace's segment start) still
+      // matches dotfiles, e.g. `a{*,b}`.
+      assert.deepStrictEqual(match(['a.foo'], 'a{*,b}'), ['a.foo']);
+    });
   });
 
   describe('leading dot', () => {


### PR DESCRIPTION
Diagnosed and fixed with AI assistance (Claude). {*.js,x} matched .js where bash/minimatch do not; see commit.