### PR TITLE
fix: apply OS detection when called without an options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const utils = require('./lib/utils');
 
 function picomatch(glob, options, returnState = false) {
   // default to os.platform()
-  if (options && (options.windows === null || options.windows === undefined)) {
+  if (!options || options.windows === null || options.windows === undefined) {
     // don't mutate the original options object
     options = { ...options, windows: utils.isWindows() };
   }

--- a/test/options.js
+++ b/test/options.js
@@ -2,7 +2,9 @@
 
 const assert = require('assert');
 const match = require('./support/match');
-const { isMatch } = require('..');
+const picomatch = require('..');
+const { isMatch } = picomatch;
+const utils = require('../lib/utils');
 
 describe('options', () => {
   describe('options.matchBase', () => {
@@ -111,6 +113,33 @@ describe('options', () => {
   });
 
   describe('options.windows', () => {
+    const isWindows = utils.isWindows;
+
+    afterEach(() => {
+      utils.isWindows = isWindows;
+    });
+
+    it('should auto-detect the platform whether or not an options object is passed', () => {
+      // Regression (#133): OS detection was skipped entirely when no options
+      // object was passed, so `picomatch(glob)` and `picomatch(glob, {})`
+      // disagreed about backslash handling on Windows.
+      utils.isWindows = () => true;
+      assert(picomatch('foo/*.js')('foo\\bar.js'), 'no options object should detect windows');
+      assert(picomatch('foo/*.js', {})('foo\\bar.js'), 'empty options object should detect windows');
+
+      utils.isWindows = () => false;
+      assert(!picomatch('foo/*.js')('foo\\bar.js'), 'no options object should detect posix');
+      assert(!picomatch('foo/*.js', {})('foo\\bar.js'), 'empty options object should detect posix');
+    });
+
+    it('should not override an explicitly defined windows option', () => {
+      utils.isWindows = () => false;
+      assert(picomatch('foo/*.js', { windows: true })('foo\\bar.js'), 'windows: true should be respected');
+
+      utils.isWindows = () => true;
+      assert(!picomatch('foo/*.js', { windows: false })('foo\\bar.js'), 'windows: false should be respected');
+    });
+
     it('should windows file paths by default', () => {
       assert.deepStrictEqual(match(['a\\b\\c.md'], '**/*.md', { windows: true }), ['a/b/c.md']);
       assert.deepStrictEqual(match(['a\\b\\c.md'], '**/*.md', { windows: false }), ['a\\b\\c.md']);


### PR DESCRIPTION
Fixes #133.

## Problem

The default entry point auto-detects the OS to choose a default for the `windows` option, but that detection is skipped when `picomatch()` is called without an options object. The result then depends on whether an (empty) options object is passed:

```js
// on Windows
picomatch('foo/*.js')('foo\\bar.js');     // false  (detection skipped)
picomatch('foo/*.js', {})('foo\\bar.js'); // true   (detection applied)
```

Both calls should behave the same.

## Cause

In `index.js` the guard requires `options` to be truthy before defaulting `windows`:

```js
if (options && (options.windows === null || options.windows === undefined)) {
  options = { ...options, windows: utils.isWindows() };
}
```

When `options` is `undefined` the whole condition is `false`, so `windows` is never defaulted and the matcher falls back to posix behavior even on Windows.

## Fix

Also apply the default when no options object is given. `{ ...undefined }` is an empty object, so the existing spread keeps working and the caller's object is never mutated. An explicit `windows: true` / `windows: false` is still respected.

## Tests

Added two cases under `options.windows` in `test/options.js`. They stub `utils.isWindows` so the behavior is asserted deterministically on any platform (the first case fails without this change). Full suite is green (`1979 passing`).
