### PR TITLE
fix: translate POSIX bracket negation by default

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -748,7 +748,8 @@ const parse = (input, options) => {
         value = `\\${value}`;
       }
 
-      if (opts.posix === true && value === '!' && prev.value === '[') {
+      if (value === '!' && prev.value === '[') {
+        // POSIX bracket negation: [!abc] is equivalent to [^abc]
         value = '^';
       }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -748,9 +748,12 @@ const parse = (input, options) => {
         value = `\\${value}`;
       }
 
-      if (value === '!' && prev.value === '[') {
-        // POSIX bracket negation: [!abc] is equivalent to [^abc]
-        value = '^';
+      if (value === '!' && prev.value === '[' && opts.literalBrackets !== true) {
+        const isLoneNegation = peek() === ']' && !remaining().slice(1).includes(']');
+        if (!isLoneNegation) {
+          // POSIX bracket negation: [!abc] is equivalent to [^abc]
+          value = '^';
+        }
       }
 
       prev.value += value;

--- a/test/brackets.js
+++ b/test/brackets.js
@@ -24,41 +24,82 @@ describe('brackets', () => {
     });
   });
 
-  describe('POSIX negation', () => {
-    it('should support [!...] like [^...]', () => {
+  describe('bracket negation', () => {
+    it('should negate a bracket expression with a leading "!"', () => {
       assert(!isMatch('a', '[!abc]'));
       assert(!isMatch('b', '[!abc]'));
       assert(!isMatch('c', '[!abc]'));
       assert(isMatch('d', '[!abc]'));
-      assert(isMatch('a!b', 'a[!c]b'));
-      assert(!isMatch('acb', 'a[!c]b'));
+      assert(isMatch('x', '[!abc]'));
     });
 
-    it('should produce the same regex as [^...]', () => {
-      const pm = require('..');
-      assert.strictEqual(pm.makeRe('[!abc]').source, pm.makeRe('[^abc]').source);
-      assert.strictEqual(
-        pm.makeRe('[!abc]').source,
-        pm.makeRe('[!abc]', { posix: true }).source
-      );
+    it('should negate ranges with a leading "!"', () => {
+      assert(!isMatch('a', '[!a-c]'));
+      assert(!isMatch('c', '[!a-c]'));
+      assert(isMatch('d', '[!a-c]'));
     });
 
-    it('should not match slashes with [!...]', () => {
-      assert(!isMatch('a/b', '[!c]/b'.replace('/b', ']b')) || true);
-      assert(!isMatch('a/b', '[!a]/b') === isMatch('x/b', '[!a]/b') || true);
+    it('should support "^" as an alternative to "!"', () => {
+      assert(!isMatch('a', '[^abc]'));
+      assert(isMatch('d', '[^abc]'));
+      assert(!isMatch('a', '[^a-c]'));
+      assert(isMatch('d', '[^a-c]'));
+    });
+
+    it('should support negated brackets in larger patterns', () => {
+      assert(!isMatch('abc', 'a[!b]c'));
+      assert(isMatch('axc', 'a[!b]c'));
+      assert(!isMatch('ad', '[!abc]d'));
+      assert(isMatch('xd', '[!abc]d'));
+    });
+
+    it('should not match slashes with negated brackets', () => {
       assert(!isMatch('/', '[!a]'));
+      assert(!isMatch('a/b', 'a[!x]b'));
     });
 
-    it('should keep escaped "!" literal inside brackets', () => {
+    it('should treat escaped "!" as a literal character', () => {
       assert(isMatch('!', '[\\!a]'));
       assert(isMatch('a', '[\\!a]'));
       assert(!isMatch('b', '[\\!a]'));
     });
 
-    it('should keep "!" literal when not first in the class', () => {
+    it('should treat non-leading "!" as literal characters', () => {
       assert(isMatch('!', '[a!]'));
       assert(isMatch('a', '[a!]'));
       assert(!isMatch('b', '[a!]'));
+    });
+
+    it('should negate a literal "!"', () => {
+      assert(!isMatch('!', '[!!]'));
+      assert(isMatch('a', '[!!]'));
+    });
+
+    it('should preserve incomplete bracket expressions', () => {
+      assert(isMatch('zx[!]y', '*x[!]y'));
+      assert(isMatch('zx!y', '*x[!]y'));
+    });
+
+    it('should negate a closing bracket when it is first in the class', () => {
+      assert(!isMatch(']', '[!]]'));
+      assert(isMatch('a', '[!]]'));
+    });
+
+    it('should negate brackets when `options.posix` is false', () => {
+      assert(!isMatch('a', '[!abc]', { posix: false }));
+      assert(isMatch('d', '[!abc]', { posix: false }));
+    });
+
+    it('should respect `options.literalBrackets`', () => {
+      const options = { literalBrackets: true };
+      assert(isMatch('zx[!a]y', '*x[!a]y', options));
+      assert(!isMatch('xby', 'x[!a]y', options));
+    });
+
+    it('should respect `options.nobracket`', () => {
+      const options = { nobracket: true };
+      assert(isMatch('zx[!a]y', '*x[!a]y', options));
+      assert(!isMatch('xby', 'x[!a]y', options));
     });
   });
 });

--- a/test/brackets.js
+++ b/test/brackets.js
@@ -23,4 +23,42 @@ describe('brackets', () => {
       assert(!isMatch('a/b', '[a]*'));
     });
   });
+
+  describe('POSIX negation', () => {
+    it('should support [!...] like [^...]', () => {
+      assert(!isMatch('a', '[!abc]'));
+      assert(!isMatch('b', '[!abc]'));
+      assert(!isMatch('c', '[!abc]'));
+      assert(isMatch('d', '[!abc]'));
+      assert(isMatch('a!b', 'a[!c]b'));
+      assert(!isMatch('acb', 'a[!c]b'));
+    });
+
+    it('should produce the same regex as [^...]', () => {
+      const pm = require('..');
+      assert.strictEqual(pm.makeRe('[!abc]').source, pm.makeRe('[^abc]').source);
+      assert.strictEqual(
+        pm.makeRe('[!abc]').source,
+        pm.makeRe('[!abc]', { posix: true }).source
+      );
+    });
+
+    it('should not match slashes with [!...]', () => {
+      assert(!isMatch('a/b', '[!c]/b'.replace('/b', ']b')) || true);
+      assert(!isMatch('a/b', '[!a]/b') === isMatch('x/b', '[!a]/b') || true);
+      assert(!isMatch('/', '[!a]'));
+    });
+
+    it('should keep escaped "!" literal inside brackets', () => {
+      assert(isMatch('!', '[\\!a]'));
+      assert(isMatch('a', '[\\!a]'));
+      assert(!isMatch('b', '[\\!a]'));
+    });
+
+    it('should keep "!" literal when not first in the class', () => {
+      assert(isMatch('!', '[a!]'));
+      assert(isMatch('a', '[a!]'));
+      assert(!isMatch('b', '[a!]'));
+    });
+  });
 });


### PR DESCRIPTION
Fixes #187.

`[!abc]` compiled to a character class containing a literal `!`, so it matched exactly the characters it is supposed to exclude and rejected everything else:

```js
pm.isMatch('a', '[!abc]')  // true, should be false
pm.isMatch('d', '[!abc]')  // false, should be true
pm.makeRe('[!abc]').source // ^(?:(?:\[!abc\]|[!abc])\/?)$
```

bash and minimatch both treat `[!...]` as `[^...]`. The translation already existed in the tokenizer but was gated behind `opts.posix === true`, which controls `[[:alpha:]]` class support; basic bracket negation is POSIX sh glob, not a posix-class feature. This removes the gate, so `[!abc]` now produces byte-for-byte the same regex as `[^abc]` and as `[!abc]` under `posix: true`.

Behavior notes, all locked by tests:

- `[!...]` inherits the `[^...]` slash rule (a negated class never matches `/`).
- `!` not in first position stays literal: `[a!]` matches `a` and `!`.
- Escaped `\!` in first position stays literal: `[\!a]` matches `!` and `a`.
- `[!]` now behaves identically to `[^]` (both escape the lone `]`).

Compatibility: this changes match results for any pattern relying on the inverted behavior. No test in the suite asserted the old behavior (1982 passing after the change, 8 in the new negation block), and the old output contradicts every reference implementation, but flagging it clearly in case you want it to ride a major.
