### PR TITLE
fix: scan full pattern when tokens are requested

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -50,7 +50,7 @@ const scan = (input, options) => {
   const opts = options || {};
 
   const length = input.length - 1;
-  const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+  const scanToEnd = opts.parts === true || opts.tokens === true || opts.scanToEnd === true;
   const slashes = [];
   const tokens = [];
   const parts = [];

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -375,6 +375,11 @@ describe('picomatch', () => {
       assertParts('foo/[0-9]/[0-9]', ['foo', '[0-9]', '[0-9]']);
       assertParts('foo[0-9]/bar[0-9]', ['foo[0-9]', 'bar[0-9]']);
     });
+
+    it('issue #62: should enable parts when tokens are requested', () => {
+      const state = scan('a/b/*/c', { tokens: true });
+      assert.deepStrictEqual(state.parts, ['a', 'b', '*', 'c']);
+    });
   });
 
   describe('.base (glob2base test patterns)', () => {


### PR DESCRIPTION
Fixes #62.

The `tokens` option is documented to automatically enable `parts`.
However, `scan()` stopped at the first glob unless `parts` or
`scanToEnd` was explicitly enabled.

For example, `a/b/*/c` produced:

- `{ parts: true }` → `['a', 'b', '*', 'c']`
- `{ tokens: true }` → `['a', 'b', '*/c']`

This change makes `tokens` enable full-pattern scanning, producing
consistent parts and tokens. A regression test covering the original
issue has also been added..
