### PR TITLE
fix: handle terminal globstars in parenthesized patterns

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1175,6 +1175,15 @@ const parse = (input, options) => {
         consume('/**', 3);
       }
 
+      // A globstar followed only by balanced closing parens is at the logical end of patterns like
+      // `test(/utils/**)` and `test?(/utils/**)`. Treat it as EOS so the trailing `/**` can match its
+      // parent path, except in negated extglobs where that would change the exclusion semantics.
+      const isEnd = eos() || (
+        state.parens > 0
+        && rest === ')'.repeat(state.parens)
+        && !extglobs.some(extglob => extglob.type === 'negate')
+      );
+
       if (prior.type === 'bos' && eos()) {
         prev.type = 'globstar';
         prev.value += value;
@@ -1185,7 +1194,7 @@ const parse = (input, options) => {
         continue;
       }
 
-      if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
+      if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && isEnd) {
         state.output = state.output.slice(0, -(prior.output + prev.output).length);
         prior.output = `(?:${prior.output}`;
 

--- a/test/issue-related.js
+++ b/test/issue-related.js
@@ -61,4 +61,15 @@ describe('issue-related tests', () => {
     assert(isMatch('a/foo.js', '**/foo.js', { dot: true }));
     assert(isMatch('foo.js', '**/foo.js', { dot: true }));
   });
+
+  it('picomatch issue#142 - should match trailing globstars in parens', () => {
+    assert(isMatch('test/utils', 'test(/utils/**)'));
+    assert(isMatch('test/utils', 'test?(/utils/**)'));
+    assert(isMatch('test/utils/file', 'test(/utils/**)'));
+    assert(isMatch('test/utils/file', 'test?(/utils/**)'));
+    assert(!isMatch('test', 'test(/utils/**)'));
+    assert(isMatch('test', 'test?(/utils/**)'));
+    assert(!isMatch('test/utils', 'test(/utils/**)', { strictSlashes: true }));
+    assert(!isMatch('test/utils', 'test(/utils/**)/file'));
+  });
 });


### PR DESCRIPTION
Treat `/**` followed only by balanced closing parentheses as terminal,
so its preceding slash remains optional just as it does at the end of
a top-level pattern.

This makes `test(/utils/**)` and `test?(/utils/**)` match `test/utils`,
while preserving strictSlashes and negated extglob behavior.

Add regression tests for parent paths, descendants, optional groups,
strict slashes, and non-terminal suffixes.

Fixes #142
Refs mrmlnc/fast-glob#484
