### PR TITLE
fix: return complete pattern parts from scan

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -50,7 +50,7 @@ const scan = (input, options) => {
   const opts = options || {};
 
   const length = input.length - 1;
-  const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+  const scanToEnd = opts.parts === true || opts.tokens === true || opts.scanToEnd === true;
   const slashes = [];
   const tokens = [];
   const parts = [];
@@ -184,15 +184,21 @@ const scan = (input, options) => {
         }
 
         if (scanToEnd === true) {
+          let parens = 0;
+
           while (eos() !== true && (code = advance())) {
             if (code === CHAR_BACKWARD_SLASH) {
               backslashes = token.backslashes = true;
-              code = advance();
+              advance();
               continue;
             }
 
-            if (code === CHAR_RIGHT_PARENTHESES) {
-              isGlob = token.isGlob = true;
+            if (code === CHAR_LEFT_PARENTHESES) {
+              parens++;
+              continue;
+            }
+
+            if (code === CHAR_RIGHT_PARENTHESES && --parens === 0) {
               finished = true;
               break;
             }
@@ -257,14 +263,21 @@ const scan = (input, options) => {
       isGlob = token.isGlob = true;
 
       if (scanToEnd === true) {
+        let parens = 1;
+
         while (eos() !== true && (code = advance())) {
-          if (code === CHAR_LEFT_PARENTHESES) {
+          if (code === CHAR_BACKWARD_SLASH) {
             backslashes = token.backslashes = true;
-            code = advance();
+            advance();
             continue;
           }
 
-          if (code === CHAR_RIGHT_PARENTHESES) {
+          if (code === CHAR_LEFT_PARENTHESES) {
+            parens++;
+            continue;
+          }
+
+          if (code === CHAR_RIGHT_PARENTHESES && --parens === 0) {
             finished = true;
             break;
           }
@@ -351,7 +364,7 @@ const scan = (input, options) => {
     let prevIndex;
 
     for (let idx = 0; idx < slashes.length; idx++) {
-      const n = prevIndex ? prevIndex + 1 : start;
+      const n = prevIndex !== undefined ? prevIndex + 1 : start;
       const i = slashes[idx];
       const value = input.slice(n, i);
       if (opts.tokens) {
@@ -364,21 +377,20 @@ const scan = (input, options) => {
         depth(tokens[idx]);
         state.maxDepth += tokens[idx].depth;
       }
-      if (idx !== 0 || value !== '') {
+      if (i >= start) {
         parts.push(value);
+        prevIndex = i;
       }
-      prevIndex = i;
     }
 
-    if (prevIndex && prevIndex + 1 < input.length) {
-      const value = input.slice(prevIndex + 1);
-      parts.push(value);
+    const n = prevIndex !== undefined ? prevIndex + 1 : start;
+    const value = input.slice(n);
+    parts.push(value);
 
-      if (opts.tokens) {
-        tokens[tokens.length - 1].value = value;
-        depth(tokens[tokens.length - 1]);
-        state.maxDepth += tokens[tokens.length - 1].depth;
-      }
+    if (opts.tokens && prevIndex && prevIndex + 1 < input.length) {
+      tokens[tokens.length - 1].value = value;
+      depth(tokens[tokens.length - 1]);
+      state.maxDepth += tokens[tokens.length - 1].depth;
     }
 
     state.slashes = slashes;

--- a/test/api.scan.js
+++ b/test/api.scan.js
@@ -322,34 +322,55 @@ describe('picomatch', () => {
       });
     });
 
+    it('should return a single part for patterns without path separators', () => {
+      assertParts('', ['']);
+      assertParts('*', ['*']);
+      assertParts('.*', ['.*']);
+      assertParts('**', ['**']);
+      assertParts('foo', ['foo']);
+      assertParts('!foo', ['foo']);
+      assertParts('foo*', ['foo*']);
+      assertParts('{1..9}', ['{1..9}']);
+      assertParts('c!(.)z', ['c!(.)z']);
+      assertParts('(b|a).(a)', ['(b|a).(a)']);
+      assertParts('+(a|b\\[)*', ['+(a|b\\[)*']);
+      assertParts('@(a|b).md', ['@(a|b).md']);
+      assertParts('(a/b)', ['(a/b)']);
+      assertParts('(a\\b)', ['(a\\b)']);
+      assertParts('foo\\[a\\/]', ['foo\\[a\\/]']);
+      assertParts('foo[/]bar', ['foo[/]bar']);
+    });
+
+    it('should preserve leading and trailing empty parts', () => {
+      assertParts('/', ['', '']);
+      assertParts('/*', ['', '*']);
+      assertParts('/a', ['', 'a']);
+      assertParts('/a/b', ['', 'a', 'b']);
+      assertParts('/a/b/', ['', 'a', 'b', '']);
+      assertParts('*/', ['*', '']);
+      assertParts('./', ['']);
+    });
+
+    it('should return parts when tokens are requested', () => {
+      assert.deepStrictEqual(scan('/', { tokens: true }).parts, ['', '']);
+      assert.deepStrictEqual(scan('/a/b', { tokens: true }).parts, ['', 'a', 'b']);
+      assert.deepStrictEqual(scan('!foo', { tokens: true }).parts, ['foo']);
+      assert.deepStrictEqual(scan('./!a/b', { tokens: true }).parts, ['a', 'b']);
+      assert.deepStrictEqual(scan('a/b/*/c', { tokens: true }).parts, ['a', 'b', '*', 'c']);
+    });
+
+    it('should split only on unnested and unescaped path separators', () => {
+      assertParts('/dev\\/@(tcp|udp)\\/*\\/*', ['', 'dev\\/@(tcp|udp)\\/*\\/*']);
+      assertParts('!(!(bar)/baz)', ['!(!(bar)/baz)']);
+      assertParts('(!(b/a))', ['(!(b/a))']);
+      assertParts('a/((b)/c)/d', ['a', '((b)/c)', 'd']);
+      assertParts('a/(b\\)/c)/d', ['a', '(b\\)/c)', 'd']);
+      assertParts('(a|b)/c', ['(a|b)', 'c']);
+      assertParts('./directory/(a|b)/*.js', ['directory', '(a|b)', '*.js']);
+      assertParts('a/@(!(b)/c)/*.js', ['a', '@(!(b)/c)', '*.js']);
+    });
+
     it('should return parts of the pattern', () => {
-      // Right now it returns []
-      // assertParts('', ['']);
-      // assertParts('*', ['*']);
-      // assertParts('.*', ['.*']);
-      // assertParts('**', ['**']);
-      // assertParts('foo', ['foo']);
-      // assertParts('foo*', ['foo*']);
-      // assertParts('/', ['', '']);
-      // assertParts('/*', ['', '*']);
-      // assertParts('./', ['']);
-      // assertParts('{1..9}', ['{1..9}']);
-      // assertParts('c!(.)z', ['c!(.)z']);
-      // assertParts('(b|a).(a)', ['(b|a).(a)']);
-      // assertParts('+(a|b\\[)*', ['+(a|b\\[)*']);
-      // assertParts('@(a|b).md', ['@(a|b).md']);
-      // assertParts('(a/b)', ['(a/b)']);
-      // assertParts('(a\\b)', ['(a\\b)']);
-      // assertParts('foo\\[a\\/]', ['foo\\[a\\/]']);
-      // assertParts('foo[/]bar', ['foo[/]bar']);
-      // assertParts('/dev\\/@(tcp|udp)\\/*\\/*', ['', '/dev\\/@(tcp|udp)\\/*\\/*']);
-
-      // Right now it returns ['*']
-      // assertParts('*/', ['*', '']);
-
-      // Right now it returns ['!(!(bar)', 'baz)']
-      // assertParts('!(!(bar)/baz)', ['!(!(bar)/baz)']);
-
       assertParts('./foo', ['foo']);
       assertParts('../foo', ['..', 'foo']);
 


### PR DESCRIPTION
Fixes #58. This PR depends on #197, because makes this fix simpler by enabling full-pattern scanning for `tokens`.

## Summary

`scan()` did not always return a complete representation of pattern segments when `parts` was enabled.

This change:

- preserves leading and trailing empty segments;
- returns a single part for patterns without path separators;
- excludes prefixes such as `!` and `./` from returned parts;
- keeps slashes inside balanced parentheses in the same part;
- handles nested and escaped parentheses;
- splits only on top-level, unescaped path separators.

## Examples

```js
scan('/', { parts: true }).parts
// ['', '']

scan('/a/b', { parts: true }).parts
// ['', 'a', 'b']

scan('(!(b/a))', { parts: true }).parts
// ['(!(b/a))']

scan('./directory/(a|b)/*.js', { parts: true }).parts
// ['directory', '(a|b)', '*.js']
```
