### PR TITLE
fix: respect dot option in brace alternatives

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -482,6 +482,24 @@ const parse = (input, options) => {
     stack.pop();
   };
 
+  // Direct brace alternatives inherit the opening brace's segment boundary.
+  const isBraceSegmentStart = () => {
+    const brace = braces[braces.length - 1];
+
+    // In `{x,@(a,*.js)}`, `parens` owns the comma, so it is not a brace boundary.
+    if (!brace || stack[stack.length - 1] !== 'braces') {
+      return false;
+    }
+
+    // Matches `{*.js,x}` and `foo/{*.js,x}`, but not `foo{*.js,x}`.
+    const braceStartsSegment = brace.prev.type === 'bos' || brace.prev.type === 'slash';
+
+    // Matches the first (`{*.js,x}`) and subsequent (`{x,*.js}`) alternatives.
+    const startsAlternative = prev.type === 'comma' || (prev.type === 'brace' && prev.value === '{');
+
+    return braceStartsSegment && startsAlternative;
+  };
+
   /**
    * Push tokens onto the tokens array. This helper speeds up
    * tokenizing by 1) helping us avoid backtracking as much as possible,
@@ -521,6 +539,11 @@ const parse = (input, options) => {
   };
 
   const extglobOpen = (type, value) => {
+    if (nodot && type === 'negate' && isBraceSegmentStart()) {
+      state.output += nodot;
+      prev.output += nodot;
+    }
+
     const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
 
     token.prev = prev;
@@ -1262,6 +1285,9 @@ const parse = (input, options) => {
       token.output = '.*?';
       if (prev.type === 'bos' || prev.type === 'slash') {
         token.output = nodot + token.output;
+      } else if (isBraceSegmentStart()) {
+        state.output += nodot;
+        prev.output += nodot;
       }
       push(token);
       continue;
@@ -1273,7 +1299,7 @@ const parse = (input, options) => {
       continue;
     }
 
-    if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+    if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot' || isBraceSegmentStart()) {
       if (prev.type === 'dot') {
         state.output += NO_DOT_SLASH;
         prev.output += NO_DOT_SLASH;

--- a/test/braces.js
+++ b/test/braces.js
@@ -25,6 +25,9 @@ describe('braces', () => {
     assert(isMatch('a {abc} b', 'a {abc} b'));
     assert(isMatch('a {a-b-c} b', 'a {a-b-c} b'));
     assert(isMatch('a {a.c} b', 'a {a.c} b'));
+    assert(isMatch('{.foo}', '{*}'));
+    assert(isMatch('{.foo}', '{*}', { bash: true }));
+    assert(isMatch('{!.foo}', '{!(x)}'));
   });
 
   it('should match literal braces when escaped', () => {

--- a/test/extglobs.js
+++ b/test/extglobs.js
@@ -86,6 +86,81 @@ describe('extglobs', () => {
       assert(isMatch('/file.dhello.ts', '/!(*.d).@(ts)'));
     });
 
+    it('should apply dotfile rules to brace alternatives at segment starts', () => {
+      const pattern = '**/{!(*.d).mts,!(*.d).cts,*.{mjs,cjs,js}}';
+      const opts = { dot: false };
+      const dotOpts = { dot: true };
+
+      assert(!isMatch('.cjs', pattern, opts));
+      assert(!isMatch('.cts', pattern, opts));
+      assert(!isMatch('.js', pattern, opts));
+      assert(!isMatch('.mjs', pattern, opts));
+      assert(!isMatch('.mts', pattern, opts));
+      assert(isMatch('a.mjs', pattern, opts));
+      assert(isMatch('ad.cts', pattern, opts));
+      assert(isMatch('ad.mts', pattern, opts));
+      assert(!isMatch('a/.cjs', pattern, opts));
+      assert(!isMatch('a/.cts', pattern, opts));
+      assert(!isMatch('a/.js', pattern, opts));
+      assert(!isMatch('a/.mjs', pattern, opts));
+      assert(!isMatch('a/.mts', pattern, opts));
+      assert(isMatch('a/a.mjs', pattern, opts));
+      assert(isMatch('a/ad.cts', pattern, opts));
+      assert(isMatch('a/ad.mts', pattern, opts));
+
+      assert(isMatch('.cjs', pattern, dotOpts));
+      assert(isMatch('.cts', pattern, dotOpts));
+      assert(isMatch('.js', pattern, dotOpts));
+      assert(isMatch('.mjs', pattern, dotOpts));
+      assert(isMatch('.mts', pattern, dotOpts));
+      assert(isMatch('a.mjs', pattern, dotOpts));
+      assert(isMatch('ad.cts', pattern, dotOpts));
+      assert(isMatch('ad.mts', pattern, dotOpts));
+      assert(isMatch('a/.cjs', pattern, dotOpts));
+      assert(isMatch('a/.cts', pattern, dotOpts));
+      assert(isMatch('a/.js', pattern, dotOpts));
+      assert(isMatch('a/.mjs', pattern, dotOpts));
+      assert(isMatch('a/.mts', pattern, dotOpts));
+      assert(isMatch('a/a.mjs', pattern, dotOpts));
+      assert(isMatch('a/ad.cts', pattern, dotOpts));
+      assert(isMatch('a/ad.mts', pattern, dotOpts));
+    });
+
+    it('should apply dotfile rules only at segment starts', () => {
+      assert(isMatch('.foo', '**/{.foo,*}'));
+      assert(!isMatch('.bar', '**/{.foo,*}'));
+      assert(isMatch('a.foo', 'a{*,b}'));
+    });
+
+    it('should apply dotfile rules to first and subsequent brace alternatives', () => {
+      assert(!isMatch('.js', '**/{*.js,x}', { dot: false }));
+      assert(!isMatch('a/.js', '**/{*.js,x}', { dot: false }));
+      assert(isMatch('.js', '**/{*.js,x}', { dot: true }));
+      assert(isMatch('a/.js', '**/{*.js,x}', { dot: true }));
+
+      assert(!isMatch('.js', '**/{x,*.js}', { dot: false }));
+      assert(!isMatch('a/.js', '**/{x,*.js}', { dot: false }));
+      assert(isMatch('.js', '**/{x,*.js}', { dot: true }));
+      assert(isMatch('a/.js', '**/{x,*.js}', { dot: true }));
+
+      assert(!isMatch('.mts', '**/{!(*.d).mts,x}', { dot: false }));
+      assert(!isMatch('a/.mts', '**/{!(*.d).mts,x}', { dot: false }));
+      assert(isMatch('.mts', '**/{!(*.d).mts,x}', { dot: true }));
+      assert(isMatch('a/.mts', '**/{!(*.d).mts,x}', { dot: true }));
+
+      assert(!isMatch('.mts', '**/{x,!(*.d).mts}', { dot: false }));
+      assert(!isMatch('a/.mts', '**/{x,!(*.d).mts}', { dot: false }));
+      assert(isMatch('.mts', '**/{x,!(*.d).mts}', { dot: true }));
+      assert(isMatch('a/.mts', '**/{x,!(*.d).mts}', { dot: true }));
+
+      assert(!isMatch('.js', '{*.js,x}', { bash: true }));
+      assert(isMatch('a.js', '{*.js,x}', { bash: true }));
+      assert(!isMatch('.js', '{x,*.js}', { bash: true }));
+      assert(isMatch('a.js', '{x,*.js}', { bash: true }));
+      assert(isMatch('a,.js', '{x,@(a,*.js)}'));
+      assert(isMatch('a,.mts', '{x,@(a,!(*.d).mts)}'));
+    });
+
     it('should support negation extglobs in patterns with slashes', () => {
       assert(!isMatch('foo/abc', 'foo/!(abc)'));
       assert(isMatch('foo/bar', 'foo/!(abc)'));
@@ -290,6 +365,13 @@ describe('extglobs', () => {
       assert(isMatch('ab.md', '*(a|b).md'));
       assert(isMatch('b.md', '*(a|b).md'));
       assert(isMatch('bb.md', '*(a|b).md'));
+    });
+
+    it('should preserve zero-length *(...) matches in brace alternatives', () => {
+      assert(isMatch('.md', '{*(a|b).md,x}'));
+      assert(isMatch('a/.md', 'a/{x,*(a|b).md}'));
+      assert(!isMatch('.a.md', '{*(a|b).md,x}', { noextglob: true }));
+      assert(isMatch('a.md', '{*(a|b).md,x}', { noextglob: true }));
     });
 
     it('should support matching file extensions with ?(...)', () => {
@@ -770,4 +852,3 @@ describe('extglobs', () => {
     assert.deepStrictEqual(match(['foo', ' foo '], '(f|o)+\\b'), ['foo'], 'Should match word boundaries');
   });
 });
-


### PR DESCRIPTION
## Summary

Fix leading-dot handling for direct brace alternatives that begin with a star wildcard (`*`) or a negated extglob (`!(...)`) when the brace group starts a path segment.

Previously, these alternatives were not recognized as segment starts because their preceding token is `{` or `,` rather than the beginning of the pattern or `/`. As a result, they could match dotfiles even when `dot` was disabled.

```js
picomatch.isMatch('.js', '**/{*.js,x}', { dot: false });
// before: true
// after:  false

picomatch.isMatch('.mts', '**/{x,!(*.d).mts}', { dot: false });
// before: true
// after:  false
```

This fixes the pattern reported in [`mrmlnc/fast-glob#405`](https://github.com/mrmlnc/fast-glob/issues/405):

```text
**/{!(*.d).mts,!(*.d).cts,*.{mjs,cjs,js}}
```

## Implementation

When parsing an ordinary `*` or `!(...)`, use the existing brace stack and token chain to determine whether the token belongs to a direct brace alternative at the beginning of a path segment.

This allows the parser to:

- handle both the first and subsequent brace alternatives;
- apply the rule only when the brace group itself starts a path segment;
- ignore commas owned by nested extglobs;
- preserve mid-segment and literal-brace behavior;
- distinguish an ordinary `*` from the `*(...)` extglob;
- preserve zero-length `*(...)` matches;
- preserve `bash`, `dot`, and `noextglob` behavior.

No additional parser metadata is introduced.

## Scope

This change handles direct, flat brace alternatives only.

Nested-brace alternatives such as `{a,{*.js,b}}` remain outside its scope. Supporting them requires propagating path-segment context through enclosing brace groups. An alternative implementation covering that case is available in [`micromatch/picomatch#193`](https://github.com/micromatch/picomatch/pull/193).

## Refs

https://github.com/mrmlnc/fast-glob/issues/405
