### PR TITLE
fix: include the backslash in [[:punct:]]

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -352,7 +352,7 @@ The following named POSIX bracket expressions are supported:
 - `[:graph:]` - Graph characters, equivalent to `[\\x21-\\x7E]`.
 - `[:lower:]` - Lowercase letters, equivalent to `[a-z]`.
 - `[:print:]` - Print characters, equivalent to `[\\x20-\\x7E ]`.
-- `[:punct:]` - Punctuation and symbols, equivalent to ``[\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~]``.
+- `[:punct:]` - Punctuation and symbols, equivalent to ``[\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~]``.
 - `[:space:]` - Extended space characters, equivalent to `[ \\t\\r\\n\\v\\f]`.
 - `[:upper:]` - Uppercase letters, equivalent to `[A-Z]`.
 - `[:word:]` -  Word characters (letters, numbers and underscores), equivalent to `[A-Za-z0-9_]`.

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ The following named POSIX bracket expressions are supported:
 * `[:graph:]` - Graph characters, equivalent to `[\\x21-\\x7E]`.
 * `[:lower:]` - Lowercase letters, equivalent to `[a-z]`.
 * `[:print:]` - Print characters, equivalent to `[\\x20-\\x7E ]`.
-* `[:punct:]` - Punctuation and symbols, equivalent to `[\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~]`.
+* `[:punct:]` - Punctuation and symbols, equivalent to `[\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~]`.
 * `[:space:]` - Extended space characters, equivalent to `[ \\t\\r\\n\\v\\f]`.
 * `[:upper:]` - Uppercase letters, equivalent to `[A-Z]`.
 * `[:word:]` -  Word characters (letters, numbers and underscores), equivalent to `[A-Za-z0-9_]`.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -81,7 +81,7 @@ const POSIX_REGEX_SOURCE = {
   graph: '\\x21-\\x7E',
   lower: 'a-z',
   print: '\\x20-\\x7E ',
-  punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+  punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~',
   space: ' \\t\\r\\n\\v\\f',
   upper: 'A-Z',
   word: 'A-Za-z0-9_',

--- a/test/posix-classes.js
+++ b/test/posix-classes.js
@@ -21,7 +21,7 @@ describe('posix classes', () => {
       assert.strictEqual(convert('[![:lower:]]'), '(?=.)[^a-z]');
       assert.strictEqual(convert('[[:digit:][:upper:][:space:]]'), '(?=.)[0-9A-Z \\t\\r\\n\\v\\f]');
       assert.strictEqual(convert('[[:xdigit:]]'), '(?=.)[A-Fa-f0-9]');
-      assert.strictEqual(convert('[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]'), '(?=.)[a-zA-Z0-9a-zA-Z \\t\\x00-\\x1F\\x7F0-9\\x21-\\x7Ea-z\\x20-\\x7E \\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~ \\t\\r\\n\\v\\fA-ZA-Fa-f0-9]');
+      assert.strictEqual(convert('[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]'), '(?=.)[a-zA-Z0-9a-zA-Z \\t\\x00-\\x1F\\x7F0-9\\x21-\\x7Ea-z\\x20-\\x7E \\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~ \\t\\r\\n\\v\\fA-ZA-Fa-f0-9]');
       assert.strictEqual(convert('[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]'), '(?=.)[^a-zA-Z0-9a-zA-Z \\t\\x00-\\x1F\\x7F0-9a-z \\t\\r\\n\\v\\fA-ZA-Fa-f0-9]');
       assert.strictEqual(convert('[a-c[:digit:]x-z]'), '(?=.)[a-c0-9x-z]');
       assert.strictEqual(convert('[_[:alpha:]][_[:alnum:]][_[:alnum:]]*'), '(?=.)[_a-zA-Z][_a-zA-Z0-9][_a-zA-Z0-9]*', []);
@@ -133,7 +133,7 @@ describe('posix classes', () => {
 
     it('should not create an invalid posix character class:', () => {
       assert.strictEqual(convert('[:al:]'), '(?:\\[:al:\\]|[:al:])');
-      assert.strictEqual(convert('[abc[:punct:][0-9]'), '(?=.)[abc\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~\\[0-9]');
+      assert.strictEqual(convert('[abc[:punct:][0-9]'), '(?=.)[abc\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~\\[0-9]');
     });
 
     it('should return `true` when the pattern matches:', () => {
@@ -262,8 +262,9 @@ describe('posix classes', () => {
       assert(isMatch('900', '[[:xdigit:]]*'));
     });
 
-    it('should match punctuation characters (\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~)', () => {
+    it('should match punctuation characters (\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~)', () => {
       assert(isMatch('!', '[[:punct:]]'));
+      assert(isMatch('\\', '[[:punct:]]'));
       assert(isMatch('?', '[[:punct:]]'));
       assert(isMatch('#', '[[:punct:]]'));
       assert(isMatch('&', '[[:punct:]]'));

--- a/test/posix-classes.js
+++ b/test/posix-classes.js
@@ -265,6 +265,7 @@ describe('posix classes', () => {
     it('should match punctuation characters (\\-!"#$%&\'()\\*+,./:;<=>?@[\\\\\\]^_`{|}~)', () => {
       assert(isMatch('!', '[[:punct:]]'));
       assert(isMatch('\\', '[[:punct:]]'));
+      assert(!isMatch('\\', '[![:punct:]]'));
       assert(isMatch('?', '[[:punct:]]'));
       assert(isMatch('#', '[[:punct:]]'));
       assert(isMatch('&', '[[:punct:]]'));


### PR DESCRIPTION
## The problem

`[[:punct:]]` does not match a backslash. The table at `lib/constants.js:84` holds 31 characters where POSIX defines 32 — the backslash is absent.

Backslash is a legal character in a POSIX filename, and bash matches it:

| pattern | subject | bash 5.2.21 | picomatch |
|---|---|---|---|
| `[[:punct:]]` | `\` | true | **false** |
| `a[[:punct:]]b` | `a\b` | true | **false** |
| `*[[:punct:]]*` | `x\y` | true | **false** |
| `[[:punct:]]` | `!` | true | true |
| `[[:punct:]]` | `a` | false | false |

The last two rows are controls: the class works, only this one character is missing.

## It is also inconsistent with picomatch's own tables

`graph` is `\x21-\x7E` and `print` is `\x20-\x7E`, so both already match the backslash:

```
graph  matches backslash: true
print  matches backslash: true
punct  matches backslash: false
alnum  matches backslash: false
```

POSIX defines `graph` as `alnum` plus `punct`. A character that is in `graph` but in neither of its two parts cannot be right, so this holds independently of what bash does.

## Why it was not caught

The `[[:punct:]]` test at `test/posix-classes.js:265` exercises `! ? # & @ + * : = |` and never a backslash. Nothing asserted the buggy behaviour, so this is an untested gap rather than a deliberate deviation.

## The change

One character added to the class in `lib/constants.js`. Two assertions embed the class source as an expected regex string (`test/posix-classes.js:24` and `:136`) and are updated to match, as is the equivalent listed at `README.md:585` and the test's own description.

`assert(isMatch('\\', '[[:punct:]]'))` is added to the existing punct test.

## Verification

Suite: 1996 passing before, 1996 passing after.

Reverting only `lib/constants.js` and keeping the tests fails 3 — the two expected-regex assertions and the new backslash one — so the added assertion exercises this bug rather than the class in general.

---

*Disclosure: this patch was prepared with AI assistance. The bash comparison, the table counts and the red/green check above were executed against this branch; happy to adjust anything on request.*
